### PR TITLE
Update dependencies: cakedc/users to 16.0.2 and robmorgan/phinx to 0.16.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "cakephp/plugin-installer": "^2.0",
         "intervention/image": "^3.6",
         "mobiledetect/mobiledetectlib": "^4.8.03",
-        "robmorgan/phinx": ">=0.16.10 <0.16.11",
+        "robmorgan/phinx": "^0.16.11",
         "tinymce/tinymce": "^8.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=8.1",
         "burzum/cakephp-service-layer": "^3.0",
-        "cakedc/users": "^15.0",
+        "cakedc/users": "^16.0",
         "cakephp/authentication": "^3.3",
         "cakephp/authorization": "^3.4",
         "cakephp/cakephp": "^5.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c1a69b637cf2057e3b30fc00961ad0e9",
+    "content-hash": "b010710360f329bb109cded51825141a",
     "packages": [
         {
             "name": "burzum/cakephp-service-layer",
@@ -128,27 +128,28 @@
         },
         {
             "name": "cakedc/users",
-            "version": "15.1.3",
+            "version": "16.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CakeDC/users.git",
-                "reference": "37747a80bccb2d359825623372c3ef8134497863"
+                "reference": "70f8d6ae2a540489b863f296a17a52c6db8a9583"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CakeDC/users/zipball/37747a80bccb2d359825623372c3ef8134497863",
-                "reference": "37747a80bccb2d359825623372c3ef8134497863",
+                "url": "https://api.github.com/repos/CakeDC/users/zipball/70f8d6ae2a540489b863f296a17a52c6db8a9583",
+                "reference": "70f8d6ae2a540489b863f296a17a52c6db8a9583",
                 "shasum": ""
             },
             "require": {
                 "cakedc/auth": "^10.1",
                 "cakephp/authentication": "^3.0",
                 "cakephp/authorization": "^3.0",
-                "cakephp/cakephp": "^5.0",
+                "cakephp/cakephp": "^5.3",
                 "php": ">=8.1"
             },
             "require-dev": {
                 "cakephp/cakephp-codesniffer": "^5.0",
+                "cakephp/migrations": "^4.5.1",
                 "endroid/qr-code": "^6.0 || ^5.0",
                 "google/recaptcha": "@stable",
                 "league/oauth1-client": "^1.7",
@@ -208,20 +209,20 @@
                 "issues": "https://github.com/CakeDC/users/issues",
                 "source": "https://github.com/CakeDC/users"
             },
-            "time": "2025-12-17T17:12:23+00:00"
+            "time": "2026-02-23T13:14:36+00:00"
         },
         {
             "name": "cakephp/authentication",
-            "version": "3.3.4",
+            "version": "3.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/authentication.git",
-                "reference": "85752168191e3a0b6d9318288b67e320b0b4d6f0"
+                "reference": "9a12edc97de43f95eb4fecf033b623d5b17b436c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/authentication/zipball/85752168191e3a0b6d9318288b67e320b0b4d6f0",
-                "reference": "85752168191e3a0b6d9318288b67e320b0b4d6f0",
+                "url": "https://api.github.com/repos/cakephp/authentication/zipball/9a12edc97de43f95eb4fecf033b623d5b17b436c",
+                "reference": "9a12edc97de43f95eb4fecf033b623d5b17b436c",
                 "shasum": ""
             },
             "require": {
@@ -237,7 +238,7 @@
                 "cakephp/cakephp": "^5.1.0",
                 "cakephp/cakephp-codesniffer": "^5.0",
                 "firebase/php-jwt": "^6.2",
-                "phpunit/phpunit": "^10.5.32 || ^11.3.3 || ^12.0.9"
+                "phpunit/phpunit": "^10.5.58 || ^11.5.3 || ^12.4"
             },
             "suggest": {
                 "cakephp/cakephp": "Install full core to use \"CookieAuthenticator\".",
@@ -276,7 +277,7 @@
                 "issues": "https://github.com/cakephp/authentication/issues",
                 "source": "https://github.com/cakephp/authentication"
             },
-            "time": "2025-11-29T15:47:28+00:00"
+            "time": "2026-01-31T00:28:31+00:00"
         },
         {
             "name": "cakephp/authorization",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b010710360f329bb109cded51825141a",
+    "content-hash": "426ae34661eb711e43c16dec21f0b73a",
     "packages": [
         {
             "name": "burzum/cakephp-service-layer",
@@ -1629,16 +1629,16 @@
         },
         {
             "name": "robmorgan/phinx",
-            "version": "0.16.10",
+            "version": "0.16.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/phinx.git",
-                "reference": "83f83ec105e55e3abba7acc23c0272b5fcf66929"
+                "reference": "a03014fea316ba021fc0776982e5bed2d10228d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/phinx/zipball/83f83ec105e55e3abba7acc23c0272b5fcf66929",
-                "reference": "83f83ec105e55e3abba7acc23c0272b5fcf66929",
+                "url": "https://api.github.com/repos/cakephp/phinx/zipball/a03014fea316ba021fc0776982e5bed2d10228d4",
+                "reference": "a03014fea316ba021fc0776982e5bed2d10228d4",
                 "shasum": ""
             },
             "require": {
@@ -1646,16 +1646,16 @@
                 "composer-runtime-api": "^2.0",
                 "php-64bit": ">=8.1",
                 "psr/container": "^1.1|^2.0",
-                "symfony/config": "^4.0|^5.0|^6.0|^7.0",
-                "symfony/console": "^6.0|^7.0"
+                "symfony/config": "^4.0|^5.0|^6.0|^7.0|^8.0",
+                "symfony/console": "^6.0|^7.0|^8.0"
             },
             "require-dev": {
                 "cakephp/cakephp-codesniffer": "^5.0",
                 "cakephp/i18n": "^5.0",
                 "ext-json": "*",
                 "ext-pdo": "*",
-                "phpunit/phpunit": "^9.5.19",
-                "symfony/yaml": "^4.0|^5.0|^6.0|^7.0"
+                "phpunit/phpunit": "^10.5",
+                "symfony/yaml": "^4.0|^5.0|^6.0|^7.0|^8.0"
             },
             "suggest": {
                 "ext-json": "Install if using JSON configuration format",
@@ -1710,9 +1710,9 @@
             ],
             "support": {
                 "issues": "https://github.com/cakephp/phinx/issues",
-                "source": "https://github.com/cakephp/phinx/tree/0.16.10"
+                "source": "https://github.com/cakephp/phinx/tree/0.16.11"
             },
-            "time": "2025-07-08T18:55:28+00:00"
+            "time": "2026-03-15T00:04:32+00:00"
         },
         {
             "name": "symfony/config",


### PR DESCRIPTION
This pull request updates dependencies in the `composer.json` file to keep the project up to date with the latest compatible versions. The most important changes are:

Dependency updates:

* Upgraded `cakedc/users` from version `^15.0` to `^16.0` to use the latest major release.
* Updated `robmorgan/phinx` from a restricted `>=0.16.10 <0.16.11` range to `^0.16.11`, allowing for newer patch releases.