### PR TITLE
Enhance dark mode, add games route, and update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         if: ${{ matrix.coverage == true }}
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v4.6.0
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # gitleaks:allow
           files: coverage.xml
@@ -286,7 +286,7 @@ jobs:
         run: npm run test:js -- --ci --coverage
 
       - name: Upload JS coverage to Codecov
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v4.6.0
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # gitleaks:allow
           files: coverage-js/clover.xml

--- a/composer.lock
+++ b/composer.lock
@@ -6061,16 +6061,16 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "8.28.0",
+            "version": "8.28.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "0cd4b30cc1037eca54091c188d260d570e61770c"
+                "reference": "66151cfbd25b50e8becd9f809fb704f01fd4d6f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/0cd4b30cc1037eca54091c188d260d570e61770c",
-                "reference": "0cd4b30cc1037eca54091c188d260d570e61770c",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/66151cfbd25b50e8becd9f809fb704f01fd4d6f2",
+                "reference": "66151cfbd25b50e8becd9f809fb704f01fd4d6f2",
                 "shasum": ""
             },
             "require": {
@@ -6082,7 +6082,7 @@
             "require-dev": {
                 "phing/phing": "3.0.1|3.1.2",
                 "php-parallel-lint/php-parallel-lint": "1.4.0",
-                "phpstan/phpstan": "2.1.40",
+                "phpstan/phpstan": "2.1.42",
                 "phpstan/phpstan-deprecation-rules": "2.0.4",
                 "phpstan/phpstan-phpunit": "2.0.16",
                 "phpstan/phpstan-strict-rules": "2.0.10",
@@ -6110,7 +6110,7 @@
             ],
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.28.0"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.28.1"
             },
             "funding": [
                 {
@@ -6122,7 +6122,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-23T21:35:24+00:00"
+            "time": "2026-03-22T17:22:38+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",


### PR DESCRIPTION
This pull request updates the Codecov GitHub Action version used in the CI workflow for both backend and JavaScript coverage uploads. The update ensures the action references a newer commit hash for version v4.6.0.

CI workflow updates:

* Updated the Codecov action commit hash for uploading backend coverage reports in `.github/workflows/ci.yml` (`codecov/codecov-action` step) to use a newer commit for v4.6.0.
* Updated the Codecov action commit hash for uploading JavaScript coverage reports in `.github/workflows/ci.yml` (`codecov/codecov-action` step) to use the same newer commit for v4.6.0.
