### PR TITLE
fix(ci): update server directory for FTP deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,4 +138,4 @@ jobs:
           username: ${{ secrets.FTP_USERNAME }}
           password: ${{ secrets.FTP_PASSWORD }}
           local-dir: build/deploy/
-          server-dir: /public_html/new.racerhistory.com/
+          server-dir: /


### PR DESCRIPTION
This pull request makes a small change to the deployment workflow. The deployment path on the server has been updated to deploy directly to the server root directory instead of the `/public_html/new.racerhistory.com/` subdirectory.
