### PR TITLE
Fix server directory for FTP deployment in CI workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,4 +138,4 @@ jobs:
           username: ${{ secrets.FTP_USERNAME }}
           password: ${{ secrets.FTP_PASSWORD }}
           local-dir: build/deploy/
-          server-dir: /public_html/new.racerhistory.com/
+          server-dir: /


### PR DESCRIPTION
This pull request makes a small update to the deployment workflow by changing the FTP server directory for deployments. The deployment will now target the root directory instead of the previous subdirectory.