### PR TITLE
Refactor BlogPostService to use SelectQuery for clarity

### DIFF
--- a/src/Service/BlogPostService.php
+++ b/src/Service/BlogPostService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace App\Service;
 
 use App\Model\Entity\BlogPost;
-use Cake\ORM\Query;
+use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Text;
@@ -119,7 +119,7 @@ class BlogPostService
     /**
      * Build the published posts query with pinned ordering.
      */
-    private function getPublishedPostsQuery(): Query
+    private function getPublishedPostsQuery(): SelectQuery
     {
         $table = $this->posts();
         $query = $table->find()


### PR DESCRIPTION
This pull request makes minor improvements to type hinting in the `BlogPostService` for better clarity and stricter type safety.

Type hint improvements:

* Changed the import and usage of the query class from `Cake\ORM\Query` to the more specific `Cake\ORM\Query\SelectQuery` in `BlogPostService.php`.
* Updated the return type of the `getPublishedPostsQuery` method from `Query` to `SelectQuery` for more accurate type hinting.
