### PR TITLE
Enhance image upload and restoration error handling

### DIFF
--- a/src/Service/ImageStorageService.php
+++ b/src/Service/ImageStorageService.php
@@ -65,7 +65,10 @@ class ImageStorageService
         /** @var \App\Model\Entity\Image|null $existing */
         $existing = $images->find()->where(['hash' => $hash])->first();
         if ($existing) {
-            $this->restoreMissingImageFiles($images, $existing, $processed);
+            $restoreError = $this->restoreMissingImageFiles($images, $existing, $processed);
+            if ($restoreError !== null) {
+                return ['success' => false, 'error' => $restoreError];
+            }
             $this->tagging->attachTags((int)$existing->id, $tags);
 
             return ['success' => true, 'image' => $existing, 'existing' => true];
@@ -163,7 +166,9 @@ class ImageStorageService
         $storageDir = $this->storageRoot() . $subdir . DS;
         $writeErrors = [];
         if (!$this->createStorageDir($storageDir, $writeErrors)) {
-            $this->lastError = end($writeErrors) ?: 'Storage directory not writable';
+            $this->lastError = $writeErrors !== []
+                ? (string)$writeErrors[count($writeErrors) - 1]
+                : 'Storage directory not writable';
 
             return null;
         }
@@ -320,16 +325,18 @@ class ImageStorageService
      * @param \App\Model\Table\ImagesTable $images
      * @param \App\Model\Entity\Image $image
      * @param array $processed
-     * @return bool True when any file or metadata was restored.
+     * @return string|null Error message when restore fails, otherwise null.
      */
-    private function restoreMissingImageFiles(ImagesTable $images, Image $image, array $processed): bool
+    private function restoreMissingImageFiles(ImagesTable $images, Image $image, array $processed): ?string
     {
         [$originalPath, $baseDir] = $this->storagePathDetails($image);
         $errors = [];
         if (!$this->createStorageDir($baseDir, $errors)) {
-            $this->lastError = end($errors) ?: 'Storage directory not writable';
+            $this->lastError = $errors !== []
+                ? (string)$errors[count($errors) - 1]
+                : 'Storage directory not writable';
 
-            return false;
+            return $this->lastError;
         }
 
         $restored = false;
@@ -342,12 +349,12 @@ class ImageStorageService
             ) {
                 $this->lastError = 'Missing original image data for restore';
 
-                return false;
+                return $this->lastError;
             }
             if (file_put_contents($originalPath, $processed['original']['data']) === false) {
                 $this->lastError = 'Failed to restore original image';
 
-                return false;
+                return $this->lastError;
             }
             $restored = true;
         }
@@ -371,12 +378,12 @@ class ImageStorageService
                 if (!isset($variant['data']) || !is_string($variant['data']) || $variant['data'] === '') {
                     $this->lastError = 'Missing data for variant ' . $name;
 
-                    return false;
+                    return $this->lastError;
                 }
                 if (file_put_contents($variantPath, $variant['data']) === false) {
                     $this->lastError = 'Failed to restore variant ' . $name;
 
-                    return false;
+                    return $this->lastError;
                 }
                 $restored = true;
             }
@@ -393,7 +400,7 @@ class ImageStorageService
         }
 
         if (!$restored && !$metadataChanged) {
-            return false;
+            return null;
         }
 
         if ($metadataChanged) {
@@ -401,7 +408,7 @@ class ImageStorageService
             $images->saveOrFail($image);
         }
 
-        return $restored || $metadataChanged;
+        return null;
     }
 
     /**

--- a/src/Service/ImageStorageService.php
+++ b/src/Service/ImageStorageService.php
@@ -335,7 +335,16 @@ class ImageStorageService
         $restored = false;
         $metadataChanged = false;
         if (!is_file($originalPath)) {
-            if (file_put_contents($originalPath, (string)($processed['original']['data'] ?? '')) === false) {
+            if (
+                !isset($processed['original']['data'])
+                || !is_string($processed['original']['data'])
+                || $processed['original']['data'] === ''
+            ) {
+                $this->lastError = 'Missing original image data for restore';
+
+                return false;
+            }
+            if (file_put_contents($originalPath, $processed['original']['data']) === false) {
                 $this->lastError = 'Failed to restore original image';
 
                 return false;
@@ -359,7 +368,12 @@ class ImageStorageService
             $variantPath = $baseDir . str_replace(['../', '..\\'], '', ltrim($variantFile, '/\\'));
 
             if (!is_file($variantPath)) {
-                if (file_put_contents($variantPath, (string)($variant['data'] ?? '')) === false) {
+                if (!isset($variant['data']) || !is_string($variant['data']) || $variant['data'] === '') {
+                    $this->lastError = 'Missing data for variant ' . $name;
+
+                    return false;
+                }
+                if (file_put_contents($variantPath, $variant['data']) === false) {
                     $this->lastError = 'Failed to restore variant ' . $name;
 
                     return false;
@@ -367,7 +381,7 @@ class ImageStorageService
                 $restored = true;
             }
 
-            if (!isset($variants[$name]) || !is_array($variants[$name]) || $variantMeta === []) {
+            if (!isset($variants[$name]) || !is_array($variants[$name])) {
                 $variants[$name] = [
                     'file' => $variantFile,
                     'width' => $variant['width'] ?? null,

--- a/src/Service/ImageStorageService.php
+++ b/src/Service/ImageStorageService.php
@@ -65,6 +65,7 @@ class ImageStorageService
         /** @var \App\Model\Entity\Image|null $existing */
         $existing = $images->find()->where(['hash' => $hash])->first();
         if ($existing) {
+            $this->restoreMissingImageFiles($images, $existing, $processed);
             $this->tagging->attachTags((int)$existing->id, $tags);
 
             return ['success' => true, 'image' => $existing, 'existing' => true];
@@ -280,15 +281,7 @@ class ImageStorageService
      */
     public function resolveImagePath(Image $image, string $variant): array
     {
-        $storagePath = $image->storage_path ?? null;
-        if ($storagePath) {
-            $path = $this->storageRoot() . str_replace(['../', '..\\'], '', $storagePath);
-            $baseDir = dirname($path) . DS;
-        } else {
-            $subdir = $image->storage_subdir ?? (date('Y') . '/' . date('m'));
-            $baseDir = $this->storageRoot() . $subdir . DS;
-            $path = $baseDir . $image->filename;
-        }
+        [$path, $baseDir] = $this->storagePathDetails($image);
         $mime = $image->mime;
 
         $variants = $image->variants;
@@ -318,6 +311,86 @@ class ImageStorageService
     }
 
     /**
+     * Restore missing original or variant files for an existing image.
+     *
+     * Uploads that match an existing hash previously returned early and left
+     * missing files untouched. That made lost variants stay lost until a manual
+     * edit regenerated them.
+     *
+     * @param \App\Model\Table\ImagesTable $images
+     * @param \App\Model\Entity\Image $image
+     * @param array $processed
+     * @return bool True when any file or metadata was restored.
+     */
+    private function restoreMissingImageFiles(ImagesTable $images, Image $image, array $processed): bool
+    {
+        [$originalPath, $baseDir] = $this->storagePathDetails($image);
+        $errors = [];
+        if (!$this->createStorageDir($baseDir, $errors)) {
+            $this->lastError = end($errors) ?: 'Storage directory not writable';
+
+            return false;
+        }
+
+        $restored = false;
+        $metadataChanged = false;
+        if (!is_file($originalPath)) {
+            if (file_put_contents($originalPath, (string)($processed['original']['data'] ?? '')) === false) {
+                $this->lastError = 'Failed to restore original image';
+
+                return false;
+            }
+            $restored = true;
+        }
+
+        $variants = $image->variants;
+        if (is_string($variants)) {
+            $variants = json_decode($variants, true);
+        }
+        $variants = is_array($variants) ? $variants : [];
+
+        $baseName = pathinfo((string)$image->filename, PATHINFO_FILENAME);
+        foreach ((array)($processed['variants'] ?? []) as $name => $variant) {
+            $variantMeta = is_array($variants[$name] ?? null) ? $variants[$name] : [];
+            $existingFile = isset($variantMeta['file']) ? (string)$variantMeta['file'] : '';
+            $variantFile = $existingFile !== ''
+                ? $existingFile
+                : $baseName . '-' . $name . '.' . (string)($variant['ext'] ?? $image->ext ?? 'jpg');
+            $variantPath = $baseDir . str_replace(['../', '..\\'], '', ltrim($variantFile, '/\\'));
+
+            if (!is_file($variantPath)) {
+                if (file_put_contents($variantPath, (string)($variant['data'] ?? '')) === false) {
+                    $this->lastError = 'Failed to restore variant ' . $name;
+
+                    return false;
+                }
+                $restored = true;
+            }
+
+            if (!isset($variants[$name]) || !is_array($variants[$name]) || $variantMeta === []) {
+                $variants[$name] = [
+                    'file' => $variantFile,
+                    'width' => $variant['width'] ?? null,
+                    'height' => $variant['height'] ?? null,
+                    'mime' => $variant['mime'] ?? null,
+                ];
+                $metadataChanged = true;
+            }
+        }
+
+        if (!$restored && !$metadataChanged) {
+            return false;
+        }
+
+        if ($metadataChanged) {
+            $image->set('variants', json_encode($variants));
+            $images->saveOrFail($image);
+        }
+
+        return $restored || $metadataChanged;
+    }
+
+    /**
      * Lookup a table instance.
      */
     private function imagesTable(): ImagesTable
@@ -326,6 +399,29 @@ class ImageStorageService
         $table = TableRegistry::getTableLocator()->get('Images');
 
         return $table;
+    }
+
+    /**
+     * Resolve the current storage path and base directory for an image.
+     *
+     * @param \App\Model\Entity\Image $image
+     * @return array{0:string,1:string}
+     */
+    private function storagePathDetails(Image $image): array
+    {
+        $storagePath = $image->storage_path ?? null;
+        if ($storagePath) {
+            $path = $this->storageRoot() . str_replace(['../', '..\\'], '', $storagePath);
+            $baseDir = dirname($path) . DS;
+
+            return [$path, $baseDir];
+        }
+
+        $subdir = $image->storage_subdir ?? (date('Y') . '/' . date('m'));
+        $baseDir = $this->storageRoot() . $subdir . DS;
+        $path = $baseDir . $image->filename;
+
+        return [$path, $baseDir];
     }
 
     /**

--- a/tests/TestCase/Service/ImageStorageServiceTest.php
+++ b/tests/TestCase/Service/ImageStorageServiceTest.php
@@ -3,9 +3,11 @@ declare(strict_types=1);
 
 namespace App\Test\TestCase\Service;
 
+use App\Service\ImageProcessor;
 use App\Service\ImageStorageService;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
+use Laminas\Diactoros\UploadedFile;
 
 class ImageStorageServiceTest extends TestCase
 {
@@ -93,6 +95,133 @@ class ImageStorageServiceTest extends TestCase
 
         $this->assertSame($legacyPath, $path);
         $this->assertSame($image->mime, $mime);
+    }
+
+    /**
+     * Tests duplicate upload restores missing variant files.
+     */
+    public function testUploadRestoresMissingVariantFilesForExistingImage(): void
+    {
+        $previousStorageRoot = Configure::read('Images.storageRoot');
+        $previousVariants = Configure::read('Images.variants');
+
+        $tempRoot = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR)
+            . DIRECTORY_SEPARATOR
+            . 'racerhistory-image-storage-'
+            . uniqid('', true)
+            . DIRECTORY_SEPARATOR;
+        mkdir($tempRoot, 0775, true);
+
+        Configure::write('Images.storageRoot', $tempRoot);
+        Configure::write('Images.variants', [
+            'thumb' => ['fit' => [150, 150], 'format' => 'webp'],
+            'medium' => ['maxWidth' => 800, 'format' => 'webp'],
+        ]);
+
+        $uploadPath = tempnam(sys_get_temp_dir(), 'img');
+        $pngData = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO8lmpwAAAAASUVORK5CYII=');
+        file_put_contents($uploadPath, $pngData);
+
+        try {
+            $images = $this->getTableLocator()->get('Images');
+            $image = $images->get(1);
+            $subdir = (string)$image->storage_subdir;
+            $baseDir = $tempRoot . str_replace('/', DIRECTORY_SEPARATOR, $subdir) . DIRECTORY_SEPARATOR;
+            if (!is_dir($baseDir)) {
+                mkdir($baseDir, 0775, true);
+            }
+
+            $originalData = 'ORIGINAL-BYTES';
+            $thumbData = 'THUMB-BYTES';
+            file_put_contents($baseDir . (string)$image->filename, $originalData);
+
+            $image = $images->patchEntity($image, [
+                'storage_subdir' => $subdir,
+                'storage_path' => $subdir . '/' . (string)$image->filename,
+                'byte_size' => strlen($originalData),
+                'width' => 100,
+                'height' => 50,
+                'hash' => hash('sha256', $originalData),
+                'variants' => json_encode([
+                    'thumb' => [
+                        'file' => 'seed-thumb.webp',
+                        'width' => 150,
+                        'height' => 150,
+                        'mime' => 'image/webp',
+                    ],
+                ]),
+            ], ['validate' => false]);
+            $images->saveOrFail($image);
+
+            $processor = $this->getMockBuilder(ImageProcessor::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['process'])
+                ->getMock();
+
+            $processor->method('process')->willReturn([
+                'original' => [
+                    'data' => $originalData,
+                    'width' => 100,
+                    'height' => 50,
+                    'mime' => 'image/png',
+                    'ext' => 'png',
+                ],
+                'variants' => [
+                    'thumb' => [
+                        'data' => $thumbData,
+                        'width' => 150,
+                        'height' => 150,
+                        'mime' => 'image/webp',
+                        'ext' => 'webp',
+                    ],
+                    'medium' => [
+                        'data' => 'MEDIUM-BYTES',
+                        'width' => 100,
+                        'height' => 50,
+                        'mime' => 'image/webp',
+                        'ext' => 'webp',
+                    ],
+                ],
+            ]);
+
+            $service = new ImageStorageService($processor, null);
+            $uploadedFile = new UploadedFile(
+                $uploadPath,
+                filesize($uploadPath),
+                UPLOAD_ERR_OK,
+                'dot.png',
+                'image/png',
+            );
+
+            $result = $service->upload($uploadedFile);
+
+            $this->assertTrue($result['success'] ?? false, 'Duplicate upload should succeed');
+            $this->assertTrue($result['existing'] ?? false, 'Duplicate upload should return existing image');
+            $this->assertSame($originalData, (string)file_get_contents($baseDir . (string)$image->filename));
+            $this->assertSame($thumbData, (string)file_get_contents($baseDir . 'seed-thumb.webp'));
+
+            $reloaded = $images->get(1);
+            $variants = $reloaded->variants;
+            if (is_string($variants)) {
+                $variants = json_decode($variants, true);
+            }
+
+            $this->assertIsArray($variants);
+            $this->assertArrayHasKey('thumb', $variants);
+            $this->assertSame('seed-thumb.webp', $variants['thumb']['file']);
+        } finally {
+            if (is_file($uploadPath)) {
+                unlink($uploadPath);
+            }
+
+            $this->clearDir($tempRoot);
+            if (is_dir($tempRoot)) {
+                rmdir($tempRoot);
+            }
+
+            Configure::write('Images.storageRoot', $previousStorageRoot);
+            Configure::write('Images.variants', $previousVariants);
+        }
     }
 
     /**

--- a/tests/TestCase/Service/ImageStorageServiceTest.php
+++ b/tests/TestCase/Service/ImageStorageServiceTest.php
@@ -158,7 +158,7 @@ class ImageStorageServiceTest extends TestCase
                 ->onlyMethods(['process'])
                 ->getMock();
 
-            $processor->method('process')->willReturn([
+            $processor->expects($this->once())->method('process')->willReturn([
                 'original' => [
                     'data' => $originalData,
                     'width' => 100,
@@ -199,6 +199,7 @@ class ImageStorageServiceTest extends TestCase
             $this->assertTrue($result['existing'] ?? false, 'Duplicate upload should return existing image');
             $this->assertSame($originalData, (string)file_get_contents($baseDir . (string)$image->filename));
             $this->assertSame($thumbData, (string)file_get_contents($baseDir . 'seed-thumb.webp'));
+            $this->assertSame('MEDIUM-BYTES', (string)file_get_contents($baseDir . 'seed-medium.webp'));
 
             $reloaded = $images->get(1);
             $variants = $reloaded->variants;
@@ -208,7 +209,15 @@ class ImageStorageServiceTest extends TestCase
 
             $this->assertIsArray($variants);
             $this->assertArrayHasKey('thumb', $variants);
+            $this->assertArrayHasKey('medium', $variants);
             $this->assertSame('seed-thumb.webp', $variants['thumb']['file']);
+            $this->assertSame(150, $variants['thumb']['width']);
+            $this->assertSame(150, $variants['thumb']['height']);
+            $this->assertSame('image/webp', $variants['thumb']['mime']);
+            $this->assertSame('seed-medium.webp', $variants['medium']['file']);
+            $this->assertSame(100, $variants['medium']['width']);
+            $this->assertSame(50, $variants['medium']['height']);
+            $this->assertSame('image/webp', $variants['medium']['mime']);
         } finally {
             if (is_file($uploadPath)) {
                 unlink($uploadPath);

--- a/tests/TestCase/Service/ImageStorageServiceTest.php
+++ b/tests/TestCase/Service/ImageStorageServiceTest.php
@@ -234,6 +234,296 @@ class ImageStorageServiceTest extends TestCase
     }
 
     /**
+     * Tests upload fails when storage directory cannot be created
+     */
+    public function testUploadFailsWhenRestoreStorageDirectoryCannotBeCreated(): void
+    {
+        $previousStorageRoot = Configure::read('Images.storageRoot');
+        $previousVariants = Configure::read('Images.variants');
+
+        $blockedRoot = tempnam(sys_get_temp_dir(), 'racerhistory-storage-block-');
+        $uploadPath = tempnam(sys_get_temp_dir(), 'img');
+        $pngData = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO8lmpwAAAAASUVORK5CYII=');
+        file_put_contents($uploadPath, $pngData);
+
+        Configure::write('Images.storageRoot', $blockedRoot);
+        Configure::write('Images.variants', [
+            'thumb' => ['fit' => [150, 150], 'format' => 'webp'],
+        ]);
+
+        try {
+            $images = $this->getTableLocator()->get('Images');
+            $image = $images->get(1);
+            $subdir = (string)$image->storage_subdir;
+            $originalData = 'ORIGINAL-BYTES';
+
+            $image = $images->patchEntity($image, [
+                'storage_subdir' => $subdir,
+                'storage_path' => $subdir . '/' . (string)$image->filename,
+                'hash' => hash('sha256', $originalData),
+                'variants' => json_encode([
+                    'thumb' => [
+                        'file' => 'seed-thumb.webp',
+                        'mime' => 'image/webp',
+                    ],
+                ]),
+            ], ['validate' => false]);
+            $images->saveOrFail($image);
+
+            $processor = $this->getMockBuilder(ImageProcessor::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['process'])
+                ->getMock();
+
+            $processor->expects($this->once())->method('process')->willReturn([
+                'original' => [
+                    'data' => $originalData,
+                    'width' => 100,
+                    'height' => 50,
+                    'mime' => 'image/png',
+                    'ext' => 'png',
+                ],
+                'variants' => [
+                    'thumb' => [
+                        'data' => 'THUMB-BYTES',
+                        'width' => 150,
+                        'height' => 150,
+                        'mime' => 'image/webp',
+                        'ext' => 'webp',
+                    ],
+                ],
+            ]);
+
+            $service = new ImageStorageService($processor, null);
+            $uploadedFile = new UploadedFile(
+                $uploadPath,
+                filesize($uploadPath),
+                UPLOAD_ERR_OK,
+                'dot.png',
+                'image/png',
+            );
+
+            $result = $service->upload($uploadedFile);
+
+            $this->assertFalse($result['success'] ?? true);
+            $this->assertStringContainsString('storage directory', (string)($result['error'] ?? ''));
+        } finally {
+            if ($blockedRoot !== false && is_file($blockedRoot)) {
+                unlink($blockedRoot);
+            }
+            if (is_file($uploadPath)) {
+                unlink($uploadPath);
+            }
+
+            Configure::write('Images.storageRoot', $previousStorageRoot);
+            Configure::write('Images.variants', $previousVariants);
+        }
+    }
+
+    /**
+     * Tests upload fails when processed variant data is missing
+     */
+    public function testUploadFailsWhenRestoreVariantDataMissing(): void
+    {
+        $previousStorageRoot = Configure::read('Images.storageRoot');
+        $previousVariants = Configure::read('Images.variants');
+
+        $tempRoot = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR)
+            . DIRECTORY_SEPARATOR
+            . 'racerhistory-image-storage-'
+            . uniqid('', true)
+            . DIRECTORY_SEPARATOR;
+        mkdir($tempRoot, 0775, true);
+
+        Configure::write('Images.storageRoot', $tempRoot);
+        Configure::write('Images.variants', [
+            'thumb' => ['fit' => [150, 150], 'format' => 'webp'],
+        ]);
+
+        $uploadPath = tempnam(sys_get_temp_dir(), 'img');
+        $pngData = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO8lmpwAAAAASUVORK5CYII=');
+        file_put_contents($uploadPath, $pngData);
+
+        try {
+            $images = $this->getTableLocator()->get('Images');
+            $image = $images->get(1);
+            $subdir = (string)$image->storage_subdir;
+            $baseDir = $tempRoot . str_replace('/', DIRECTORY_SEPARATOR, $subdir) . DIRECTORY_SEPARATOR;
+            if (!is_dir($baseDir)) {
+                mkdir($baseDir, 0775, true);
+            }
+
+            $originalData = 'ORIGINAL-BYTES';
+            file_put_contents($baseDir . (string)$image->filename, $originalData);
+
+            $image = $images->patchEntity($image, [
+                'storage_subdir' => $subdir,
+                'storage_path' => $subdir . '/' . (string)$image->filename,
+                'hash' => hash('sha256', $originalData),
+                'variants' => json_encode([
+                    'thumb' => [
+                        'file' => 'seed-thumb.webp',
+                        'mime' => 'image/webp',
+                    ],
+                ]),
+            ], ['validate' => false]);
+            $images->saveOrFail($image);
+
+            $processor = $this->getMockBuilder(ImageProcessor::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['process'])
+                ->getMock();
+
+            $processor->expects($this->once())->method('process')->willReturn([
+                'original' => [
+                    'data' => $originalData,
+                    'width' => 100,
+                    'height' => 50,
+                    'mime' => 'image/png',
+                    'ext' => 'png',
+                ],
+                'variants' => [
+                    'thumb' => [
+                        'width' => 150,
+                        'height' => 150,
+                        'mime' => 'image/webp',
+                        'ext' => 'webp',
+                    ],
+                ],
+            ]);
+
+            $service = new ImageStorageService($processor, null);
+            $uploadedFile = new UploadedFile(
+                $uploadPath,
+                filesize($uploadPath),
+                UPLOAD_ERR_OK,
+                'dot.png',
+                'image/png',
+            );
+
+            $result = $service->upload($uploadedFile);
+
+            $this->assertFalse($result['success'] ?? true);
+            $this->assertSame('Missing data for variant thumb', (string)($result['error'] ?? ''));
+            $this->assertFileDoesNotExist($baseDir . 'seed-thumb.webp');
+        } finally {
+            if (is_file($uploadPath)) {
+                unlink($uploadPath);
+            }
+
+            $this->clearDir($tempRoot);
+            if (is_dir($tempRoot)) {
+                rmdir($tempRoot);
+            }
+
+            Configure::write('Images.storageRoot', $previousStorageRoot);
+            Configure::write('Images.variants', $previousVariants);
+        }
+    }
+
+    /**
+     * Tests upload fails when writing variant bytes to nested path fails
+     */
+    public function testUploadFailsWhenRestoreVariantWriteFails(): void
+    {
+        $previousStorageRoot = Configure::read('Images.storageRoot');
+        $previousVariants = Configure::read('Images.variants');
+
+        $tempRoot = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR)
+            . DIRECTORY_SEPARATOR
+            . 'racerhistory-image-storage-'
+            . uniqid('', true)
+            . DIRECTORY_SEPARATOR;
+        mkdir($tempRoot, 0775, true);
+
+        Configure::write('Images.storageRoot', $tempRoot);
+        Configure::write('Images.variants', [
+            'thumb' => ['fit' => [150, 150], 'format' => 'webp'],
+        ]);
+
+        $uploadPath = tempnam(sys_get_temp_dir(), 'img');
+        $pngData = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO8lmpwAAAAASUVORK5CYII=');
+        file_put_contents($uploadPath, $pngData);
+
+        try {
+            $images = $this->getTableLocator()->get('Images');
+            $image = $images->get(1);
+            $subdir = (string)$image->storage_subdir;
+            $baseDir = $tempRoot . str_replace('/', DIRECTORY_SEPARATOR, $subdir) . DIRECTORY_SEPARATOR;
+            if (!is_dir($baseDir)) {
+                mkdir($baseDir, 0775, true);
+            }
+
+            $originalData = 'ORIGINAL-BYTES';
+            file_put_contents($baseDir . (string)$image->filename, $originalData);
+
+            $image = $images->patchEntity($image, [
+                'storage_subdir' => $subdir,
+                'storage_path' => $subdir . '/' . (string)$image->filename,
+                'hash' => hash('sha256', $originalData),
+                'variants' => json_encode([
+                    'thumb' => [
+                        'file' => 'nested/path/seed-thumb.webp',
+                        'mime' => 'image/webp',
+                    ],
+                ]),
+            ], ['validate' => false]);
+            $images->saveOrFail($image);
+
+            $processor = $this->getMockBuilder(ImageProcessor::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['process'])
+                ->getMock();
+
+            $processor->expects($this->once())->method('process')->willReturn([
+                'original' => [
+                    'data' => $originalData,
+                    'width' => 100,
+                    'height' => 50,
+                    'mime' => 'image/png',
+                    'ext' => 'png',
+                ],
+                'variants' => [
+                    'thumb' => [
+                        'data' => 'THUMB-BYTES',
+                        'width' => 150,
+                        'height' => 150,
+                        'mime' => 'image/webp',
+                        'ext' => 'webp',
+                    ],
+                ],
+            ]);
+
+            $service = new ImageStorageService($processor, null);
+            $uploadedFile = new UploadedFile(
+                $uploadPath,
+                filesize($uploadPath),
+                UPLOAD_ERR_OK,
+                'dot.png',
+                'image/png',
+            );
+
+            $result = $service->upload($uploadedFile);
+
+            $this->assertFalse($result['success'] ?? true);
+            $this->assertSame('Failed to restore variant thumb', (string)($result['error'] ?? ''));
+            $this->assertFileDoesNotExist($baseDir . 'nested/path/seed-thumb.webp');
+        } finally {
+            if (is_file($uploadPath)) {
+                unlink($uploadPath);
+            }
+
+            $this->clearDir($tempRoot);
+            if (is_dir($tempRoot)) {
+                rmdir($tempRoot);
+            }
+
+            Configure::write('Images.storageRoot', $previousStorageRoot);
+            Configure::write('Images.variants', $previousVariants);
+        }
+    }
+
+    /**
      * Runs the clear dir routine.
      *
      * @param string $dir


### PR DESCRIPTION
This pull request introduces improvements to the image upload and storage process, primarily by adding robust handling for restoring missing image files and refactoring path resolution logic for better maintainability. The most significant changes include the addition of a method to restore missing files when an image with an existing hash is uploaded, and the extraction of storage path logic into a helper function. These updates enhance reliability and code clarity.

**Image restoration and upload reliability:**
* Added `restoreMissingImageFiles` method to automatically restore missing original or variant files when an uploaded image matches an existing hash, ensuring lost variants are recovered without manual intervention. (`src/Service/ImageStorageService.php`)
* Updated the `upload` method to call `restoreMissingImageFiles` and return an error if restoration fails, improving error handling for duplicate uploads with missing files. (`src/Service/ImageStorageService.php`)

**Path resolution refactoring:**
* Extracted storage path and base directory resolution logic into a new private `storagePathDetails` method, reducing code duplication and improving clarity. (`src/Service/ImageStorageService.php`)
* Updated `resolveImagePath` to use the new `storagePathDetails` method for determining file paths, simplifying the function. (`src/Service/ImageStorageService.php`)

**Error handling improvements:**
* Improved error message assignment in `persistNewImage` to handle cases where the write errors array may be empty, ensuring more accurate error reporting. (`src/Service/ImageStorageService.php`)