### PR TITLE
Fix admin URL generation for image management caching issues

### DIFF
--- a/src/View/Helper/ImageServeHelper.php
+++ b/src/View/Helper/ImageServeHelper.php
@@ -32,6 +32,21 @@ class ImageServeHelper extends Helper
     }
 
     /**
+     * Build the admin serve path for an image id.
+     *
+     * @param string|int $id
+     */
+    public function adminPath(int|string $id): string
+    {
+        $idInt = (int)$id;
+        if ($idInt <= 0) {
+            return '';
+        }
+
+        return '/admin/images/serve/' . $idInt;
+    }
+
+    /**
      * Build a query string (including leading '?') for supported parameters.
      *
      * @param array<string, mixed> $params
@@ -63,6 +78,22 @@ class ImageServeHelper extends Helper
     }
 
     /**
+     * Build a full admin serve URL for an image id.
+     *
+     * @param string|int $id
+     * @param array<string, mixed> $params
+     */
+    public function adminUrl(int|string $id, array $params = []): string
+    {
+        $path = $this->adminPath($id);
+        if ($path === '') {
+            return '';
+        }
+
+        return $path . $this->query($params);
+    }
+
+    /**
      * Build a public serve URL from an Image entity-like object.
      *
      * Automatically injects `v` from `hash` or `modified` when not explicitly provided.
@@ -77,6 +108,40 @@ class ImageServeHelper extends Helper
             return '';
         }
 
+        $params = $this->injectVersionParam($image, $params);
+
+        return $this->url($id, $params);
+    }
+
+    /**
+     * Build an admin serve URL from an Image entity-like object.
+     *
+     * Automatically injects `v` from `hash` or `modified` when not explicitly provided.
+     *
+     * @param object $image An object with `id` and optionally `hash` and/or `modified`.
+     * @param array<string, mixed> $params
+     */
+    public function adminUrlForImage(object $image, array $params = []): string
+    {
+        $id = (int)($image->id ?? 0);
+        if ($id <= 0) {
+            return '';
+        }
+
+        $params = $this->injectVersionParam($image, $params);
+
+        return $this->adminUrl($id, $params);
+    }
+
+    /**
+     * Ensure URL params include a cache-busting `v` value for image-like objects.
+     *
+     * @param object $image
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>
+     */
+    private function injectVersionParam(object $image, array $params): array
+    {
         if (!array_key_exists('v', $params) || $params['v'] === null || $params['v'] === '') {
             $v = '';
             if (!empty($image->hash) && is_string($image->hash)) {
@@ -89,7 +154,7 @@ class ImageServeHelper extends Helper
             }
         }
 
-        return $this->url($id, $params);
+        return $params;
     }
 
     /**

--- a/templates/Admin/Images/crop_thumb.php
+++ b/templates/Admin/Images/crop_thumb.php
@@ -31,7 +31,7 @@ $this->assign('title', 'Crop Thumbnail');
                         Click and drag on the image to select the area to use for the thumbnail. The thumbnail will be scaled to 150×150px.
                     </p>
                     <div id="crop-container" style="max-width: 100%; max-height: 600px; overflow: hidden; position: relative; background: #f5f5f5; margin-bottom: 15px;">
-                        <?php $serveUrl = $this->ImageServe->urlForImage($image); ?>
+                        <?php $serveUrl = $this->ImageServe->adminUrlForImage($image); ?>
                         <img
                             id="crop-image"
                             src="<?= h($serveUrl) ?>"

--- a/templates/Admin/Images/edit.php
+++ b/templates/Admin/Images/edit.php
@@ -10,10 +10,10 @@ $this->assign('title', 'Edit Image');
   <h1 class="mb-4">Edit Image #<?= h($image->id) ?></h1>
   <div class="row g-4">
     <div class="col-md-4">
-      <?php $serveUrl = $this->ImageServe->urlForImage($image); ?>
+      <?php $serveUrl = $this->ImageServe->adminUrlForImage($image); ?>
       <figure>
         <img src="<?= h($serveUrl) ?>" alt="Preview" class="img-fluid rounded border" />
-        <figcaption class="mt-2 small text-muted">Original (public)</figcaption>
+        <figcaption class="mt-2 small text-muted">Original</figcaption>
       </figure>
       <?php $variants = is_string($image->variants) ? json_decode($image->variants, true) : (array)$image->variants; ?>
       <?php if ($variants) : ?>
@@ -22,7 +22,7 @@ $this->assign('title', 'Edit Image');
                 <?php
                 $meta = (array)$meta;
                 // Always use the stored variant so custom crops (e.g., thumb) are shown.
-                $thumbUrl = $this->ImageServe->urlForImage($image, ['variant' => (string)$name]);
+                $thumbUrl = $this->ImageServe->adminUrlForImage($image, ['variant' => (string)$name]);
                 ?>
             <div class="col-4 text-center">
               <img src="<?= h($thumbUrl) ?>" alt="<?= h($name) ?>" class="img-fluid border rounded" />

--- a/templates/Admin/Images/index.php
+++ b/templates/Admin/Images/index.php
@@ -27,7 +27,7 @@ $this->assign('title', 'Images');
         <td>
           <?php
           // Use stored thumb variant so custom crops are shown
-            $thumbUrl = $this->ImageServe->urlForImage($img, [
+            $thumbUrl = $this->ImageServe->adminUrlForImage($img, [
             'variant' => 'thumb',
             ]);
             ?>

--- a/templates/Admin/Images/manipulate.php
+++ b/templates/Admin/Images/manipulate.php
@@ -6,7 +6,7 @@
 ?>
 
 <div class="container-fluid mt-4">
-    <?php $serveBase = $this->ImageServe->urlForImage($image); ?>
+    <?php $serveBase = $this->ImageServe->adminUrlForImage($image); ?>
     <div class="row">
         <div class="col-12">
             <div class="d-flex align-items-center justify-content-between mb-4">


### PR DESCRIPTION
This pull request introduces new helper methods for generating admin-specific image URLs and updates the admin image templates to use these new methods. The changes ensure that all image URLs in the admin interface use the correct admin route and benefit from consistent cache-busting behavior.

**Admin image URL handling:**

* Added `adminPath`, `adminUrl`, and `adminUrlForImage` methods to `ImageServeHelper` to generate admin-specific image paths and URLs, mirroring the public equivalents but with `/admin/images/serve/` routes. These methods also ensure cache-busting via the `v` parameter. [[1]](diffhunk://#diff-469e19c5405f0e02232ef3a21ed31892f5b499b88454f21e1c0dc93374bc9d76R34-R48) [[2]](diffhunk://#diff-469e19c5405f0e02232ef3a21ed31892f5b499b88454f21e1c0dc93374bc9d76R80-R95) [[3]](diffhunk://#diff-469e19c5405f0e02232ef3a21ed31892f5b499b88454f21e1c0dc93374bc9d76R111-R144)

**Template updates for admin routes:**

* Updated all admin image-related templates (`crop_thumb.php`, `edit.php`, `index.php`, `manipulate.php`) to use the new `adminUrlForImage` method instead of the public `urlForImage`, ensuring images are served from the admin route throughout the admin interface. [[1]](diffhunk://#diff-c7441e010c4dc267623291d08492c51b11c912e2910d4c3c1140684465ab0a93L34-R34) [[2]](diffhunk://#diff-305992d018203281d80af7c0aaf893ba3502b3d42a91b605f7ad8c0a13f00ab5L13-R16) [[3]](diffhunk://#diff-305992d018203281d80af7c0aaf893ba3502b3d42a91b605f7ad8c0a13f00ab5L25-R25) [[4]](diffhunk://#diff-34c19f786f23b1ed4e4f12751f2668ca26b6a75e67bca7d18066b2c115370d5eL30-R30) [[5]](diffhunk://#diff-0a5836e5983e70c2ad1a076eae0cbf7f40c91b5d20cafaa7be03c40a478f2776L9-R9)

**Code cleanup and consistency:**

* Refactored version parameter injection (`injectVersionParam`) to be used by both public and admin URL methods, ensuring consistent cache-busting across both routes. [[1]](diffhunk://#diff-469e19c5405f0e02232ef3a21ed31892f5b499b88454f21e1c0dc93374bc9d76R111-R144) [[2]](diffhunk://#diff-469e19c5405f0e02232ef3a21ed31892f5b499b88454f21e1c0dc93374bc9d76L92-R157)
