### PR TITLE
Standardize image URL generation and enhance data handling in admin

### DIFF
--- a/src/Service/OpponentAdminService.php
+++ b/src/Service/OpponentAdminService.php
@@ -75,8 +75,8 @@ class OpponentAdminService
             'Opponents.id',
             'Opponents.opponent_name',
             'Opponents.place_id',
-            'Places.place_city',
-            'Places.place_state',
+            'place_city' => 'Places.place_city',
+            'place_state' => 'Places.place_state',
         ];
         if ($hasShortColumn) {
             $selectFields[] = 'Opponents.opponent_short';

--- a/src/Service/SiteAdminService.php
+++ b/src/Service/SiteAdminService.php
@@ -73,8 +73,8 @@ class SiteAdminService
             'Sites.id',
             'Sites.site_name',
             'Sites.place_id',
-            'Places.place_city',
-            'Places.place_state',
+            'place_city' => 'Places.place_city',
+            'place_state' => 'Places.place_state',
         ];
         if ($hasCapacityColumn) {
             $selectFields[] = 'Sites.capacity';

--- a/src/View/Helper/ImageServeHelper.php
+++ b/src/View/Helper/ImageServeHelper.php
@@ -32,21 +32,6 @@ class ImageServeHelper extends Helper
     }
 
     /**
-     * Build the admin serve path for an image id.
-     *
-     * @param string|int $id
-     */
-    public function adminPath(int|string $id): string
-    {
-        $idInt = (int)$id;
-        if ($idInt <= 0) {
-            return '';
-        }
-
-        return '/admin/images/serve/' . $idInt;
-    }
-
-    /**
      * Build a query string (including leading '?') for supported parameters.
      *
      * @param array<string, mixed> $params
@@ -78,25 +63,7 @@ class ImageServeHelper extends Helper
     }
 
     /**
-     * Build a full admin serve URL for an image id.
-     *
-     * @param string|int $id
-     * @param array<string, mixed> $params
-     */
-    public function adminUrl(int|string $id, array $params = []): string
-    {
-        $path = $this->adminPath($id);
-        if ($path === '') {
-            return '';
-        }
-
-        return $path . $this->query($params);
-    }
-
-    /**
      * Build a public serve URL from an Image entity-like object.
-     *
-     * Automatically injects `v` from `hash` or `modified` when not explicitly provided.
      *
      * @param object $image An object with `id` and optionally `hash` and/or `modified`.
      * @param array<string, mixed> $params
@@ -108,53 +75,7 @@ class ImageServeHelper extends Helper
             return '';
         }
 
-        $params = $this->injectVersionParam($image, $params);
-
-        return $this->url($id, $params);
-    }
-
-    /**
-     * Build an admin serve URL from an Image entity-like object.
-     *
-     * Automatically injects `v` from `hash` or `modified` when not explicitly provided.
-     *
-     * @param object $image An object with `id` and optionally `hash` and/or `modified`.
-     * @param array<string, mixed> $params
-     */
-    public function adminUrlForImage(object $image, array $params = []): string
-    {
-        $id = (int)($image->id ?? 0);
-        if ($id <= 0) {
-            return '';
-        }
-
-        $params = $this->injectVersionParam($image, $params);
-
-        return $this->adminUrl($id, $params);
-    }
-
-    /**
-     * Ensure URL params include a cache-busting `v` value for image-like objects.
-     *
-     * @param object $image
-     * @param array<string, mixed> $params
-     * @return array<string, mixed>
-     */
-    private function injectVersionParam(object $image, array $params): array
-    {
-        if (!array_key_exists('v', $params) || $params['v'] === null || $params['v'] === '') {
-            $v = '';
-            if (!empty($image->hash) && is_string($image->hash)) {
-                $v = $image->hash;
-            } elseif (($image->modified ?? null) instanceof DateTimeInterface) {
-                $v = (string)$image->modified->getTimestamp();
-            }
-            if ($v !== '') {
-                $params['v'] = $v;
-            }
-        }
-
-        return $params;
+            return $this->url($id, $params);
     }
 
     /**

--- a/templates/Admin/Images/crop_thumb.php
+++ b/templates/Admin/Images/crop_thumb.php
@@ -31,7 +31,7 @@ $this->assign('title', 'Crop Thumbnail');
                         Click and drag on the image to select the area to use for the thumbnail. The thumbnail will be scaled to 150×150px.
                     </p>
                     <div id="crop-container" style="max-width: 100%; max-height: 600px; overflow: hidden; position: relative; background: #f5f5f5; margin-bottom: 15px;">
-                        <?php $serveUrl = $this->ImageServe->adminUrlForImage($image); ?>
+                        <?php $serveUrl = $this->ImageServe->urlForImage($image); ?>
                         <img
                             id="crop-image"
                             src="<?= h($serveUrl) ?>"

--- a/templates/Admin/Images/edit.php
+++ b/templates/Admin/Images/edit.php
@@ -10,7 +10,7 @@ $this->assign('title', 'Edit Image');
   <h1 class="mb-4">Edit Image #<?= h($image->id) ?></h1>
   <div class="row g-4">
     <div class="col-md-4">
-      <?php $serveUrl = $this->ImageServe->adminUrlForImage($image); ?>
+      <?php $serveUrl = $this->ImageServe->urlForImage($image); ?>
       <figure>
         <img src="<?= h($serveUrl) ?>" alt="Preview" class="img-fluid rounded border" />
         <figcaption class="mt-2 small text-muted">Original</figcaption>
@@ -22,7 +22,7 @@ $this->assign('title', 'Edit Image');
                 <?php
                 $meta = (array)$meta;
                 // Always use the stored variant so custom crops (e.g., thumb) are shown.
-                $thumbUrl = $this->ImageServe->adminUrlForImage($image, ['variant' => (string)$name]);
+                $thumbUrl = $this->ImageServe->urlForImage($image, ['variant' => (string)$name]);
                 ?>
             <div class="col-4 text-center">
               <img src="<?= h($thumbUrl) ?>" alt="<?= h($name) ?>" class="img-fluid border rounded" />

--- a/templates/Admin/Images/index.php
+++ b/templates/Admin/Images/index.php
@@ -27,7 +27,7 @@ $this->assign('title', 'Images');
         <td>
           <?php
           // Use stored thumb variant so custom crops are shown
-            $thumbUrl = $this->ImageServe->adminUrlForImage($img, [
+            $thumbUrl = $this->ImageServe->urlForImage($img, [
             'variant' => 'thumb',
             ]);
             ?>

--- a/templates/Admin/Images/manipulate.php
+++ b/templates/Admin/Images/manipulate.php
@@ -6,7 +6,7 @@
 ?>
 
 <div class="container-fluid mt-4">
-    <?php $serveBase = $this->ImageServe->adminUrlForImage($image); ?>
+    <?php $serveBase = $this->ImageServe->urlForImage($image); ?>
     <div class="row">
         <div class="col-12">
             <div class="d-flex align-items-center justify-content-between mb-4">

--- a/tests/TestCase/Controller/Admin/OpponentsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/OpponentsControllerTest.php
@@ -56,6 +56,20 @@ class OpponentsControllerTest extends TestCase
     }
 
     /**
+     * Tests datatables include resolved place label.
+     */
+    public function testDatatablesIncludesPlaceLabel(): void
+    {
+        $this->mockIdentity();
+        $this->get('/admin/opponents/datatables?draw=1&start=0&length=25');
+        $this->assertResponseOk();
+
+        $body = json_decode((string)$this->_response->getBody(), true);
+        $this->assertNotEmpty($body['data']);
+        $this->assertSame('Murray, KY', $body['data'][0]['place']);
+    }
+
+    /**
      * Tests datatables search filters.
      */
     public function testDatatablesSearchFilters(): void

--- a/tests/TestCase/Controller/Admin/SitesControllerTest.php
+++ b/tests/TestCase/Controller/Admin/SitesControllerTest.php
@@ -56,6 +56,20 @@ class SitesControllerTest extends TestCase
     }
 
     /**
+     * Tests datatables include resolved place label.
+     */
+    public function testDatatablesIncludesPlaceLabel(): void
+    {
+        $this->mockIdentity();
+        $this->get('/admin/sites/datatables?draw=1&start=0&length=25');
+        $this->assertResponseOk();
+
+        $body = json_decode((string)$this->_response->getBody(), true);
+        $this->assertNotEmpty($body['data']);
+        $this->assertSame('Murray, KY', $body['data'][0]['place']);
+    }
+
+    /**
      * Tests datatables search filters.
      */
     public function testDatatablesSearchFilters(): void

--- a/tests/TestCase/View/Helper/ImageServeHelperTest.php
+++ b/tests/TestCase/View/Helper/ImageServeHelperTest.php
@@ -98,7 +98,6 @@ class ImageServeHelperTest extends TestCase
         $parts = parse_url($url);
         parse_str($parts['query'] ?? '', $parsed);
 
-        $this->assertSame('abc123', $parsed['v'] ?? null);
         $this->assertSame('100', (string)$parsed['w']);
     }
 


### PR DESCRIPTION
This pull request primarily removes all admin-specific image serving helper methods and their usages, consolidating image URL generation to use only the public methods. It also updates the data table field mappings for places and adds new test coverage for place label resolution in datatables. Below are the most important changes:

**Image Serving Helper Refactor:**

* Removed all `admin*` methods from `ImageServeHelper` (such as `adminPath`, `adminUrl`, `adminUrlForImage`) and the private `injectVersionParam` method, simplifying the interface to use only public image serving methods. All usages in admin templates have been updated to use `urlForImage` instead. [[1]](diffhunk://#diff-469e19c5405f0e02232ef3a21ed31892f5b499b88454f21e1c0dc93374bc9d76L34-L48) [[2]](diffhunk://#diff-469e19c5405f0e02232ef3a21ed31892f5b499b88454f21e1c0dc93374bc9d76L80-L100) [[3]](diffhunk://#diff-469e19c5405f0e02232ef3a21ed31892f5b499b88454f21e1c0dc93374bc9d76L111-L159) [[4]](diffhunk://#diff-c7441e010c4dc267623291d08492c51b11c912e2910d4c3c1140684465ab0a93L34-R34) [[5]](diffhunk://#diff-305992d018203281d80af7c0aaf893ba3502b3d42a91b605f7ad8c0a13f00ab5L13-R13) [[6]](diffhunk://#diff-305992d018203281d80af7c0aaf893ba3502b3d42a91b605f7ad8c0a13f00ab5L25-R25) [[7]](diffhunk://#diff-34c19f786f23b1ed4e4f12751f2668ca26b6a75e67bca7d18066b2c115370d5eL30-R30) [[8]](diffhunk://#diff-0a5836e5983e70c2ad1a076eae0cbf7f40c91b5d20cafaa7be03c40a478f2776L9-R9)

**Data Table Field Mapping Improvements:**

* Updated the field mappings in `buildDataTablesResponse` for both `OpponentAdminService` and `SiteAdminService` to use associative keys (`'place_city' => 'Places.place_city'`, etc.), improving clarity and consistency in the returned data. [[1]](diffhunk://#diff-4231a6ff37f54e4b437b67b4db806bbe4d1c1962a7fbcc55b74b8d368a1080aaL78-R79) [[2]](diffhunk://#diff-2abd107c76467e432ef741a19051fbe8fd5d7e1b6358db0c603d7e628e2362c2L76-R77)

**Test Coverage Enhancements:**

* Added new tests in `OpponentsControllerTest` and `SitesControllerTest` to assert that the datatables response includes the resolved place label, ensuring correct data is returned for the place field. [[1]](diffhunk://#diff-a6d916ab091d4ef74fc07eb8d24658ccb3f10796dfe2a36d59f18fa2ef1ab570R58-R71) [[2]](diffhunk://#diff-4e0cfd48cfbf73ccee919536f5a590afa77385aa7fb2f56ab6846812d5f0a7b7R58-R71)

**Test Update for Version Parameter:**

* Updated `ImageServeHelperTest` to remove the assertion for the `v` (version) parameter, reflecting the removal of automatic version injection in the helper.
