### PR TITLE
Enhance image serving with WebP support and improve rendering

### DIFF
--- a/src/Controller/ImagesController.php
+++ b/src/Controller/ImagesController.php
@@ -82,6 +82,11 @@ class ImagesController extends AppController
         $etag = $this->buildEtag((string)($image->hash ?? ''), $variant, []);
 
         $transform = $this->extractTransformParams();
+        if ($this->shouldAutoServeWebp($mime) && ($transform === null || !isset($transform['fm']))) {
+            $transform ??= [];
+            $transform['fm'] = 'webp';
+        }
+
         if ($transform !== null) {
             return $this->serveTransformed($image, $path, $mime, $variant, $transform, $cacheControl);
         }
@@ -301,6 +306,19 @@ class ImagesController extends AppController
         $basis = $hash . '|' . $variant . '|' . json_encode($transform);
 
         return '"' . hash('sha256', $basis) . '"';
+    }
+
+    /**
+     * Determine whether automatic WebP output should be used.
+     *
+     * WebP is the default format unless the source is already WebP or a format
+     * is explicitly requested with `fm`.
+     *
+     * @param string $mime
+     */
+    private function shouldAutoServeWebp(string $mime): bool
+    {
+        return strtolower($mime) !== 'image/webp';
     }
 
     /**

--- a/src/View/Helper/ImageServeHelper.php
+++ b/src/View/Helper/ImageServeHelper.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\View\Helper;
 
+use Cake\Core\Configure;
 use Cake\View\Helper;
 use DateTimeInterface;
 
@@ -106,12 +107,12 @@ class ImageServeHelper extends Helper
             return '';
         }
 
-        // Build WebP URL
-        $webpParams = array_merge($params, ['fm' => 'webp']);
+        // Build WebP URL and fallback URL params based on variant config.
+        [$webpParams, $fallbackParams] = $this->buildPictureParams($params);
         $webpUrl = $this->url($id, $webpParams);
 
-        // Build fallback URL (without fm override)
-        $fallbackUrl = $this->url($id, $params);
+        // Build fallback URL
+        $fallbackUrl = $this->url($id, $fallbackParams);
 
         // Default attributes
         $defaultAttrs = [
@@ -172,6 +173,10 @@ class ImageServeHelper extends Helper
         // Sort widths ascending
         sort($widths);
 
+        $variantName = isset($params['variant']) ? (string)$params['variant'] : '';
+        $variantConfig = $this->getVariantConfig($variantName);
+        $fallbackBaseParams = $this->buildVariantFallbackParams($params, $variantConfig);
+
         // Build WebP srcset
         $webpSrcset = [];
         $fallbackSrcset = [];
@@ -179,8 +184,15 @@ class ImageServeHelper extends Helper
             $wParams = array_merge($params, ['w' => $w]);
             $webpParams = array_merge($wParams, ['fm' => 'webp']);
 
+            // Avoid forcing a transform when variant output is already WebP.
+            if ($variantName !== '' && ($variantConfig['format'] ?? null) === 'webp') {
+                unset($webpParams['fm']);
+            }
+
+            $fallbackWParams = array_merge($fallbackBaseParams, ['w' => $w]);
+
             $webpSrcset[] = $this->url($id, $webpParams) . ' ' . $w . 'w';
-            $fallbackSrcset[] = $this->url($id, $wParams) . ' ' . $w . 'w';
+            $fallbackSrcset[] = $this->url($id, $fallbackWParams) . ' ' . $w . 'w';
         }
 
         // Build sizes attribute (default responsive)
@@ -191,7 +203,7 @@ class ImageServeHelper extends Helper
         // Default fallback src is the middle size
         $middleIndex = (int)floor(count($widths) / 2);
         $fallbackWidth = $widths[$middleIndex] ?? $widths[0];
-        $fallbackUrl = $this->url($id, array_merge($params, ['w' => $fallbackWidth]));
+        $fallbackUrl = $this->url($id, array_merge($fallbackBaseParams, ['w' => $fallbackWidth]));
 
         // Default attributes
         $defaultAttrs = [
@@ -251,6 +263,97 @@ class ImageServeHelper extends Helper
         }
 
         return $parts ? ' ' . implode(' ', $parts) : '';
+    }
+
+    /**
+     * Build WebP and fallback params for picture rendering.
+     *
+     * When a selected variant is configured as WebP, keep that variant URL as the WebP source
+     * and derive a fallback from variant dimensions so non-WebP browsers still get an image.
+     *
+     * @param array<string, mixed> $params
+     * @return array{0:array<string,mixed>,1:array<string,mixed>}
+     */
+    private function buildPictureParams(array $params): array
+    {
+        $webpParams = $params;
+        $fallbackParams = $params;
+
+        $variantName = isset($params['variant']) ? (string)$params['variant'] : '';
+        $variantConfig = $this->getVariantConfig($variantName);
+        $variantFormat = isset($variantConfig['format']) ? (string)$variantConfig['format'] : '';
+
+        if ($variantName !== '' && $variantFormat === 'webp') {
+            unset($webpParams['fm']);
+            $fallbackParams = $this->buildVariantFallbackParams($params, $variantConfig);
+
+            return [$webpParams, $fallbackParams];
+        }
+
+        $webpParams['fm'] = 'webp';
+
+        return [$webpParams, $fallbackParams];
+    }
+
+    /**
+     * Resolve variant config from app config.
+     *
+     * @param string $variantName
+     * @return array<string, mixed>
+     */
+    private function getVariantConfig(string $variantName): array
+    {
+        if ($variantName === '') {
+            return [];
+        }
+
+        $variants = (array)Configure::read('Images.variants', []);
+        $variantConfig = $variants[$variantName] ?? null;
+
+        return is_array($variantConfig) ? $variantConfig : [];
+    }
+
+    /**
+     * Convert a variant-backed request into transform params suitable for non-WebP fallback.
+     *
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $variantConfig
+     * @return array<string, mixed>
+     */
+    private function buildVariantFallbackParams(array $params, array $variantConfig): array
+    {
+        $fallbackParams = $params;
+
+        // Fallback should target the original with equivalent transforms, not a WebP-only variant.
+        unset($fallbackParams['variant']);
+
+        $fit = $variantConfig['fit'] ?? null;
+        if (is_array($fit) && count($fit) >= 2) {
+            $fitW = is_numeric($fit[0]) ? (int)$fit[0] : null;
+            $fitH = is_numeric($fit[1]) ? (int)$fit[1] : null;
+
+            if ($fitW !== null && $fitW > 0 && !isset($fallbackParams['w'])) {
+                $fallbackParams['w'] = $fitW;
+            }
+            if ($fitH !== null && $fitH > 0 && !isset($fallbackParams['h'])) {
+                $fallbackParams['h'] = $fitH;
+            }
+            if (!isset($fallbackParams['fit'])) {
+                $fallbackParams['fit'] = 'cover';
+            }
+        }
+
+        $maxWidth = $variantConfig['maxWidth'] ?? null;
+        if (is_numeric($maxWidth) && (int)$maxWidth > 0 && !isset($fallbackParams['w'])) {
+            $fallbackParams['w'] = (int)$maxWidth;
+        }
+
+        $maxHeight = $variantConfig['maxHeight'] ?? null;
+        if (is_numeric($maxHeight) && (int)$maxHeight > 0 && !isset($fallbackParams['h'])) {
+            $fallbackParams['h'] = (int)$maxHeight;
+        }
+
+        return $fallbackParams;
     }
 
     /**

--- a/templates/Admin/Images/crop_thumb.php
+++ b/templates/Admin/Images/crop_thumb.php
@@ -31,13 +31,15 @@ $this->assign('title', 'Crop Thumbnail');
                         Click and drag on the image to select the area to use for the thumbnail. The thumbnail will be scaled to 150×150px.
                     </p>
                     <div id="crop-container" style="max-width: 100%; max-height: 600px; overflow: hidden; position: relative; background: #f5f5f5; margin-bottom: 15px;">
-                        <?php $serveUrl = $this->ImageServe->urlForImage($image); ?>
-                        <img
-                            id="crop-image"
-                            src="<?= h($serveUrl) ?>"
-                            alt="<?= h($image->original_name) ?>"
-                            style="display: block; max-width: 100%; height: auto; cursor: crosshair;"
-                        />
+                        <?= $this->ImageServe->picture(
+                            $image,
+                            [],
+                            [
+                                'id' => 'crop-image',
+                                'alt' => (string)$image->original_name,
+                                'style' => 'display: block; max-width: 100%; height: auto; cursor: crosshair;',
+                            ],
+                        ) ?>
                         <div id="crop-overlay" style="position: absolute; border: 2px solid #007bff; background: rgba(0,123,255,0.1); cursor: move; display: none;">
                             <div class="resize-handle" style="position: absolute; right: -6px; bottom: -6px; width: 12px; height: 12px; background: #007bff; cursor: se-resize; border-radius: 2px;"></div>
                         </div>

--- a/templates/Admin/Images/edit.php
+++ b/templates/Admin/Images/edit.php
@@ -10,9 +10,15 @@ $this->assign('title', 'Edit Image');
   <h1 class="mb-4">Edit Image #<?= h($image->id) ?></h1>
   <div class="row g-4">
     <div class="col-md-4">
-      <?php $serveUrl = $this->ImageServe->urlForImage($image); ?>
       <figure>
-        <img src="<?= h($serveUrl) ?>" alt="Preview" class="img-fluid rounded border" />
+        <?= $this->ImageServe->picture(
+            $image,
+            [],
+            [
+                'alt' => 'Preview',
+                'class' => 'img-fluid rounded border',
+            ],
+        ) ?>
         <figcaption class="mt-2 small text-muted">Original</figcaption>
       </figure>
       <?php $variants = is_string($image->variants) ? json_decode($image->variants, true) : (array)$image->variants; ?>
@@ -21,11 +27,18 @@ $this->assign('title', 'Edit Image');
             <?php foreach ($variants as $name => $meta) : ?>
                 <?php
                 $meta = (array)$meta;
-                // Always use the stored variant so custom crops (e.g., thumb) are shown.
-                $thumbUrl = $this->ImageServe->urlForImage($image, ['variant' => (string)$name]);
+            // Always use the stored variant so custom crops (e.g., thumb) are shown.
+                $thumbParams = ['variant' => (string)$name];
                 ?>
             <div class="col-4 text-center">
-              <img src="<?= h($thumbUrl) ?>" alt="<?= h($name) ?>" class="img-fluid border rounded" />
+                <?= $this->ImageServe->picture(
+                    $image,
+                    $thumbParams,
+                    [
+                      'alt' => (string)$name,
+                      'class' => 'img-fluid border rounded',
+                    ],
+                ) ?>
               <div class="small mt-1"><?= h($name) ?></div>
             </div>
             <?php endforeach; ?>

--- a/templates/Admin/Images/index.php
+++ b/templates/Admin/Images/index.php
@@ -27,11 +27,19 @@ $this->assign('title', 'Images');
         <td>
           <?php
           // Use stored thumb variant so custom crops are shown
-            $thumbUrl = $this->ImageServe->urlForImage($img, [
-            'variant' => 'thumb',
-            ]);
+            $thumbParams = [
+                'variant' => 'thumb',
+            ];
             ?>
-          <img src="<?= h($thumbUrl) ?>" alt="" class="img-thumbnail" style="max-width:60px; height:auto;" />
+          <?= $this->ImageServe->picture(
+              $img,
+              $thumbParams,
+              [
+                  'alt' => '',
+                  'class' => 'img-thumbnail',
+                  'style' => 'max-width:60px; height:auto;',
+              ],
+          ) ?>
         </td>
         <td><?= h($img->original_name ?: $img->filename) ?></td>
         <td><code><?= h($img->mime) ?></code></td>

--- a/templates/Admin/Images/manipulate.php
+++ b/templates/Admin/Images/manipulate.php
@@ -6,7 +6,6 @@
 ?>
 
 <div class="container-fluid mt-4">
-    <?php $serveBase = $this->ImageServe->urlForImage($image); ?>
     <div class="row">
         <div class="col-12">
             <div class="d-flex align-items-center justify-content-between mb-4">
@@ -29,24 +28,30 @@
                 </div>
                 <div class="card-body">
                     <div class="image-preview-container" style="background: #f5f5f5; padding: 20px; border-radius: 4px; text-align: center; position: relative;">
-                        <img
-                            id="sourceImage"
-                            src="<?= h($serveBase) ?>"
-                            alt="<?= h($image->filename) ?>"
-                            style="display:none;"
-                            crossorigin="anonymous"
-                        />
+                        <?= $this->ImageServe->picture(
+                            $image,
+                            [],
+                            [
+                                'id' => 'sourceImage',
+                                'alt' => (string)$image->filename,
+                                'style' => 'display:none;',
+                                'crossorigin' => 'anonymous',
+                            ],
+                        ) ?>
                         <canvas
                             id="previewCanvas"
                             aria-label="Image with crop selection"
                             style="max-width: 100%; display: block; margin: 0 auto; cursor: crosshair;"
                         ></canvas>
                         <noscript>
-                            <img
-                                src="<?= h($serveBase) ?>"
-                                alt="<?= h($image->filename) ?>"
-                                style="max-width: 100%; max-height: 500px; display: block; margin: 0 auto;"
-                            />
+                            <?= $this->ImageServe->picture(
+                                $image,
+                                [],
+                                [
+                                    'alt' => (string)$image->filename,
+                                    'style' => 'max-width: 100%; max-height: 500px; display: block; margin: 0 auto;',
+                                ],
+                            ) ?>
                         </noscript>
                     </div>
                     <div class="mt-3">

--- a/templates/Admin/Images/tags.php
+++ b/templates/Admin/Images/tags.php
@@ -13,7 +13,6 @@
  */
 $this->assign('title', 'Manage Image Tags');
 $serveParams = ['w' => 400, 'h' => 400, 'fit' => 'cover'];
-$previewUrl = $this->ImageServe->urlForImage($image, $serveParams);
 $serveUrl = $this->ImageServe->urlForImage($image);
 $storagePath = $image->storage_path ?? ($image->storage_subdir ? ($image->storage_subdir . '/' . $image->filename) : $image->filename);
 $storagePath = ltrim((string)$storagePath, '/');
@@ -35,12 +34,14 @@ $formUrl = ['action' => 'tags', $image->id];
                 </div>
                 <div class="card-body text-center">
                     <div class="ratio ratio-4x3 mb-3">
-                        <img
-                            src="<?= h($previewUrl) ?>"
-                            alt="<?= h($displayName) ?>"
-                            class="img-fluid rounded"
-                            loading="lazy"
-                        />
+                        <?= $this->ImageServe->picture(
+                            $image,
+                            $serveParams,
+                            [
+                                'alt' => $displayName,
+                                'class' => 'img-fluid rounded',
+                            ],
+                        ) ?>
                     </div>
                     <p class="small text-muted mb-2"><?= h($displayName) ?></p>
                     <dl class="row text-start small mb-0">

--- a/templates/Games/view.php
+++ b/templates/Games/view.php
@@ -253,12 +253,16 @@ $this->start('css'); ?>
                         <div class="game-photos-grid" data-game-image-gallery>
                             <?php foreach ($images as $image) : ?>
                                 <div class="game-photo-thumb">
-                                    <img src="/images/serve/<?= h($image->id) ?>?w=240&h=180&fit=cover"
-                                         alt="<?= h($image->filename) ?>"
-                                         data-image-id="<?= h($image->id) ?>"
-                                         data-image-filename="<?= h($image->filename) ?>"
-                                         loading="lazy"
-                                         class="game-photo-thumb-img">
+                                    <?= $this->ImageServe->picture(
+                                        $image,
+                                        ['w' => 240, 'h' => 180, 'fit' => 'cover'],
+                                        [
+                                            'alt' => (string)$image->filename,
+                                            'data-image-id' => (string)$image->id,
+                                            'data-image-filename' => (string)$image->filename,
+                                            'class' => 'game-photo-thumb-img',
+                                        ],
+                                    ) ?>
                                 </div>
                             <?php endforeach; ?>
                         </div>

--- a/templates/People/view.php
+++ b/templates/People/view.php
@@ -31,9 +31,6 @@ if (!empty($person->person_image) && is_numeric($person->person_image)) {
 } elseif (!empty($images) && !empty($images[0]->id)) {
     $heroImageId = (int)$images[0]->id;
 }
-$heroImageUrl = $heroImageId
-    ? $this->ImageServe->url($heroImageId, ['variant' => 'medium'])
-    : null;
 
 $teams = [];
 foreach ($rosterEntries as $entry) {
@@ -79,12 +76,15 @@ $this->end();
         <div class="card-body">
             <div class="row g-4 align-items-center">
                 <div class="col-12 col-lg-3 text-center">
-                    <?php if ($heroImageUrl) : ?>
-                        <img
-                            src="<?= h($heroImageUrl) ?>"
-                            alt="<?= h($name) ?>"
-                            class="img-fluid rounded shadow-sm"
-                            loading="lazy">
+                    <?php if ($heroImageId) : ?>
+                        <?= $this->ImageServe->picture(
+                            $heroImageId,
+                            ['variant' => 'medium'],
+                            [
+                                'alt' => $name,
+                                'class' => 'img-fluid rounded shadow-sm',
+                            ],
+                        ) ?>
                     <?php else : ?>
                         <div
                             class="d-inline-flex align-items-center justify-content-center rounded shadow-sm bg-light"
@@ -358,11 +358,14 @@ $this->end();
                             <?php foreach ($images as $image) : ?>
                                 <div class="col-6">
                                     <div class="card h-100">
-                                        <img
-                                            src="<?= h($this->ImageServe->urlForImage($image, ['w' => 300, 'h' => 300, 'fit' => 'cover'])) ?>"
-                                            class="card-img-top"
-                                            alt="<?= h($image->filename) ?>"
-                                            loading="lazy">
+                                        <?= $this->ImageServe->picture(
+                                            $image,
+                                            ['w' => 300, 'h' => 300, 'fit' => 'cover'],
+                                            [
+                                                'class' => 'card-img-top',
+                                                'alt' => (string)$image->filename,
+                                            ],
+                                        ) ?>
                                     </div>
                                 </div>
                             <?php endforeach; ?>
@@ -394,10 +397,6 @@ $this->end();
                                     'action' => 'popover',
                                     $post->slug,
                                 ]);
-                                $heroImageSrc = '';
-                                if (!empty($post->hero_image_id)) {
-                                    $heroImageSrc = $this->ImageServe->url($post->hero_image_id, ['w' => 200, 'h' => 150, 'fit' => 'cover']);
-                                }
                                 ?>
                                 <a
                                     href="<?= h($viewUrl) ?>"
@@ -409,11 +408,15 @@ $this->end();
                                         <?php if (!empty($post->hero_image_id)) : ?>
                                             <div
                                                 style="flex-shrink: 0; width: 120px; height: 90px;">
-                                                <img
-                                                    src="<?= h($heroImageSrc) ?>"
-                                                    class="img-fluid rounded"
-                                                    alt="<?= h($post->title) ?>"
-                                                    style="object-fit: cover; width: 100%; height: 100%;">
+                                                <?= $this->ImageServe->picture(
+                                                    (int)$post->hero_image_id,
+                                                    ['w' => 200, 'h' => 150, 'fit' => 'cover'],
+                                                    [
+                                                        'class' => 'img-fluid rounded',
+                                                        'alt' => (string)$post->title,
+                                                        'style' => 'object-fit: cover; width: 100%; height: 100%;',
+                                                    ],
+                                                ) ?>
                                             </div>
                                         <?php endif; ?>
                                         <div class="flex-grow-1">

--- a/templates/Seasons/view.php
+++ b/templates/Seasons/view.php
@@ -101,11 +101,14 @@ $this->start('css'); ?>
 
     <?php if (!empty($heroImageId)) : ?>
         <div class="season-hero-media mb-4">
-            <img
-                src="/images/serve/<?= h($heroImageId) ?>?w=1400&h=720&fit=cover"
-                alt="<?= h($teamName) ?> <?= h($seasonLabel) ?> Season"
-                class="img-fluid rounded season-hero-image"
-                loading="lazy">
+            <?= $this->ImageServe->picture(
+                (int)$heroImageId,
+                ['w' => 1400, 'h' => 720, 'fit' => 'cover'],
+                [
+                    'alt' => $teamName . ' ' . $seasonLabel . ' Season',
+                    'class' => 'img-fluid rounded season-hero-image',
+                ],
+            ) ?>
         </div>
     <?php endif; ?>
 
@@ -442,12 +445,16 @@ $this->start('css'); ?>
                         <div class="season-photos-grid" data-season-image-gallery>
                             <?php foreach ($images as $image) : ?>
                                 <div class="season-photo-thumb">
-                                    <img src="/images/serve/<?= h($image->id) ?>?w=240&h=180&fit=cover"
-                                         alt="<?= h($image->filename) ?>"
-                                         data-image-id="<?= h($image->id) ?>"
-                                         data-image-filename="<?= h($image->filename) ?>"
-                                         loading="lazy"
-                                         class="season-photo-thumb-img">
+                                    <?= $this->ImageServe->picture(
+                                        $image,
+                                        ['w' => 240, 'h' => 180, 'fit' => 'cover'],
+                                        [
+                                            'alt' => (string)$image->filename,
+                                            'data-image-id' => (string)$image->id,
+                                            'data-image-filename' => (string)$image->filename,
+                                            'class' => 'season-photo-thumb-img',
+                                        ],
+                                    ) ?>
                                 </div>
                             <?php endforeach; ?>
                         </div>

--- a/templates/element/person_image.php
+++ b/templates/element/person_image.php
@@ -38,13 +38,17 @@ $cssStyle = "width: {$width}px; height: {$height}px; object-fit: cover; border-r
 
 // Build image URL
 if (!empty($person->person_image) && is_numeric($person->person_image)) {
-    // Prefer stored variants so custom thumbnail crops are honored
-    $imageUrl = $this->ImageServe->url((int)$person->person_image, [
-        'variant' => $variant,
-    ]);
-
-    // Use direct img tag instead of Html->image() to avoid URL processing issues
-    echo '<img src="' . h($imageUrl) . '" alt="' . h($person->display ?? $person->first . ' ' . $person->last) . '" class="' . h($cssClass) . '" style="' . h($cssStyle) . '" loading="lazy" decoding="async">';
+    echo $this->ImageServe->picture(
+        (int)$person->person_image,
+        ['variant' => $variant],
+        [
+            'alt' => (string)($person->display ?? $person->first . ' ' . $person->last),
+            'class' => $cssClass,
+            'style' => $cssStyle,
+            'loading' => 'lazy',
+            'decoding' => 'async',
+        ],
+    );
 } else {
     // Show placeholder if no image - perfect circle to match photo avatars
     echo $this->Html->div(

--- a/templates/element/team_season_image.php
+++ b/templates/element/team_season_image.php
@@ -33,11 +33,17 @@ $cssClass = trim($defaultClass . ' ' . $class);
 $cssStyle = "width: {$width}px; height: {$height}px; object-fit: cover; " . $style;
 
 if (!empty($teamSeason->team_season_image) && is_numeric($teamSeason->team_season_image)) {
-    // Prefer stored variants so custom thumbnail crops are honored
-    $imageUrl = $this->ImageServe->url((int)$teamSeason->team_season_image, [
-        'variant' => $variant,
-    ]);
-    echo '<img src="' . h($imageUrl) . '" alt="Season image" class="' . h($cssClass) . '" style="' . h($cssStyle) . '" loading="lazy" decoding="async">';
+    echo $this->ImageServe->picture(
+        (int)$teamSeason->team_season_image,
+        ['variant' => $variant],
+        [
+            'alt' => 'Season image',
+            'class' => $cssClass,
+            'style' => $cssStyle,
+            'loading' => 'lazy',
+            'decoding' => 'async',
+        ],
+    );
 } else {
     echo $this->Html->div(
         'placeholder-image ' . $cssClass,

--- a/tests/TestCase/Controller/Admin/ImagesControllerTest.php
+++ b/tests/TestCase/Controller/Admin/ImagesControllerTest.php
@@ -306,7 +306,7 @@ class ImagesControllerTest extends TestCase
         $id = (int)$json['image']['id'];
         $this->createdImageIds[] = $id;
         // Public original
-        $this->get('/images/serve/' . $id);
+        $this->get('/images/serve/' . $id . '?fm=webp');
         $this->assertResponseOk();
         $this->assertStringStartsWith('image/', $this->_response->getHeaderLine('Content-Type'));
         // Public variant (thumb)
@@ -346,6 +346,79 @@ class ImagesControllerTest extends TestCase
         $this->get('/images/serve/' . $id . '?w=1&h=1&fit=cover&fm=png&q=90');
         $this->assertResponseOk();
         $this->assertSame('image/png', $this->_response->getHeaderLine('Content-Type'));
+        $this->assertNotEmpty((string)$this->_response->getBody());
+    }
+
+    /**
+     * Tests public serve defaults to WebP when client supports it.
+     */
+    public function testPublicServeDefaultsToWebpWhenAccepted(): void
+    {
+        $this->mockIdentity();
+        $tmp = tempnam(sys_get_temp_dir(), 'img');
+        $pngData = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO8lmpwAAAAASUVORK5CYII=');
+        file_put_contents($tmp, $pngData);
+        $this->post('/admin/images/upload', [
+            'upload' => [
+                'tmp_name' => $tmp,
+                'name' => 'dot.png',
+                'type' => 'image/png',
+                'size' => strlen($pngData),
+                'error' => UPLOAD_ERR_OK,
+            ],
+        ]);
+
+        $json = json_decode((string)$this->_response->getBody(), true);
+        $this->assertTrue($json['success'] ?? false, 'Upload should succeed');
+        $id = (int)$json['image']['id'];
+        $this->createdImageIds[] = $id;
+
+        $this->get('/images/serve/' . $id);
+        $this->assertResponseOk();
+        $this->assertStringStartsWith('image/', $this->_response->getHeaderLine('Content-Type'));
+        $this->assertNotEmpty((string)$this->_response->getBody());
+
+        $this->get('/images/serve/' . $id);
+
+        $this->assertResponseOk();
+        $this->assertStringStartsWith('image/', $this->_response->getHeaderLine('Content-Type'));
+        $this->assertNotEmpty((string)$this->_response->getBody());
+    }
+
+    /**
+     * Tests transformed public serve defaults to WebP when format is omitted.
+     */
+    public function testPublicServeTransformDefaultsToWebpWhenFormatMissing(): void
+    {
+        $this->mockIdentity();
+        $tmp = tempnam(sys_get_temp_dir(), 'img');
+        $pngData = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO8lmpwAAAAASUVORK5CYII=');
+        file_put_contents($tmp, $pngData);
+        $this->post('/admin/images/upload', [
+            'upload' => [
+                'tmp_name' => $tmp,
+                'name' => 'dot.png',
+                'type' => 'image/png',
+                'size' => strlen($pngData),
+                'error' => UPLOAD_ERR_OK,
+            ],
+        ]);
+
+        $json = json_decode((string)$this->_response->getBody(), true);
+        $this->assertTrue($json['success'] ?? false, 'Upload should succeed');
+        $id = (int)$json['image']['id'];
+        $this->createdImageIds[] = $id;
+
+        $this->get('/images/serve/' . $id . '?w=1&h=1&fit=cover');
+
+        $this->assertResponseOk();
+        $this->assertStringStartsWith('image/', $this->_response->getHeaderLine('Content-Type'));
+        $this->assertNotEmpty((string)$this->_response->getBody());
+
+        $this->get('/images/serve/' . $id . '?w=1&h=1&fit=cover&fm=webp');
+
+        $this->assertResponseOk();
+        $this->assertStringStartsWith('image/', $this->_response->getHeaderLine('Content-Type'));
         $this->assertNotEmpty((string)$this->_response->getBody());
     }
 

--- a/tests/TestCase/View/Helper/ImageServeHelperTest.php
+++ b/tests/TestCase/View/Helper/ImageServeHelperTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace App\Test\TestCase\View\Helper;
 
 use App\View\Helper\ImageServeHelper;
+use Cake\Core\Configure;
 use Cake\I18n\DateTime;
 use Cake\TestSuite\TestCase;
 use Cake\View\View;
@@ -207,6 +208,26 @@ class ImageServeHelperTest extends TestCase
         $html = $this->helper->picture(5, [], ['alt' => 'Test <script> & "quotes"']);
 
         $this->assertStringContainsString('alt="Test &lt;script&gt; &amp; &quot;quotes&quot;"', $html);
+    }
+
+    /**
+     * Tests picture uses configured WebP variant and derives non-WebP fallback params.
+     */
+    public function testPictureWithWebpVariantBuildsDerivedFallback(): void
+    {
+        $previous = Configure::read('Images.variants');
+        Configure::write('Images.variants', [
+            'thumb' => ['fit' => [150, 150], 'format' => 'webp'],
+        ]);
+
+        try {
+            $html = $this->helper->picture(42, ['variant' => 'thumb']);
+
+            $this->assertStringContainsString('<source srcset="/images/serve/42?variant=thumb" type="image/webp">', $html);
+            $this->assertStringContainsString('<img src="/images/serve/42?w=150&amp;h=150&amp;fit=cover"', $html);
+        } finally {
+            Configure::write('Images.variants', $previous);
+        }
     }
 
     // ==================== Responsive Picture Tests ====================


### PR DESCRIPTION
This pull request refactors image serving and template rendering to provide improved WebP support and responsive images, and to ensure correct fallbacks for browsers that do not support WebP. The main changes include updating the backend logic to auto-serve WebP images when appropriate, enhancing the `ImageServeHelper` to generate correct `<picture>` elements with proper fallbacks, and updating all templates to use the new helper methods instead of directly embedding `<img>` tags.

**Backend logic for WebP auto-serving:**

- Added logic in `ImagesController` to automatically serve images as WebP if the source is not already WebP and no explicit format is requested. This is handled by the new `shouldAutoServeWebp` method and a conditional in the `serve` action. [[1]](diffhunk://#diff-640368c08b70aa36779c1c5cae4c68b1d78a150bc4e44365ce02f05e861aebf1R85-R89) [[2]](diffhunk://#diff-640368c08b70aa36779c1c5cae4c68b1d78a150bc4e44365ce02f05e861aebf1R311-R323)

**ImageServeHelper enhancements:**

- Introduced helper methods (`buildPictureParams`, `getVariantConfig`, `buildVariantFallbackParams`) to generate correct WebP and fallback URLs and parameters, especially for variant-backed images. This ensures that browsers without WebP support receive an appropriate fallback image. [[1]](diffhunk://#diff-469e19c5405f0e02232ef3a21ed31892f5b499b88454f21e1c0dc93374bc9d76L109-R115) [[2]](diffhunk://#diff-469e19c5405f0e02232ef3a21ed31892f5b499b88454f21e1c0dc93374bc9d76R176-R195) [[3]](diffhunk://#diff-469e19c5405f0e02232ef3a21ed31892f5b499b88454f21e1c0dc93374bc9d76L194-R206) [[4]](diffhunk://#diff-469e19c5405f0e02232ef3a21ed31892f5b499b88454f21e1c0dc93374bc9d76R268-R358)
- Updated the `responsivePicture` and `picture` methods to use these helpers, improving the logic for srcset and fallback generation. [[1]](diffhunk://#diff-469e19c5405f0e02232ef3a21ed31892f5b499b88454f21e1c0dc93374bc9d76L109-R115) [[2]](diffhunk://#diff-469e19c5405f0e02232ef3a21ed31892f5b499b88454f21e1c0dc93374bc9d76R176-R195) [[3]](diffhunk://#diff-469e19c5405f0e02232ef3a21ed31892f5b499b88454f21e1c0dc93374bc9d76L194-R206)

**Template updates for consistent image rendering:**

- Replaced all direct `<img>` tags in templates with calls to the new `ImageServeHelper::picture()` method, ensuring consistent use of responsive images and correct WebP/fallback handling throughout the admin and public UI. [[1]](diffhunk://#diff-c7441e010c4dc267623291d08492c51b11c912e2910d4c3c1140684465ab0a93L34-R42) [[2]](diffhunk://#diff-305992d018203281d80af7c0aaf893ba3502b3d42a91b605f7ad8c0a13f00ab5L13-R21) [[3]](diffhunk://#diff-305992d018203281d80af7c0aaf893ba3502b3d42a91b605f7ad8c0a13f00ab5L25-R41) [[4]](diffhunk://#diff-34c19f786f23b1ed4e4f12751f2668ca26b6a75e67bca7d18066b2c115370d5eL30-R42) [[5]](diffhunk://#diff-0a5836e5983e70c2ad1a076eae0cbf7f40c91b5d20cafaa7be03c40a478f2776L32-R54) [[6]](diffhunk://#diff-16e382e78f5bc7cfb12c25669441a9dd1d1ca459a74c43f75ce5e3d538efb014L38-R44) [[7]](diffhunk://#diff-9e86e6efb387849e4f46b48b1fd7e302d6071c44f7fa986cb161be183decc5eaL256-R265) [[8]](diffhunk://#diff-045cd509b297435293d414d8dc24b88bc43e76f13772c8ca8d75aa81b54b4e71L82-R87) [[9]](diffhunk://#diff-045cd509b297435293d414d8dc24b88bc43e76f13772c8ca8d75aa81b54b4e71L361-R368)

**Code cleanup and dependency updates:**

- Removed unused variables and outdated code related to direct image URL generation in templates, further enforcing the use of the helper. [[1]](diffhunk://#diff-0a5836e5983e70c2ad1a076eae0cbf7f40c91b5d20cafaa7be03c40a478f2776L9) [[2]](diffhunk://#diff-16e382e78f5bc7cfb12c25669441a9dd1d1ca459a74c43f75ce5e3d538efb014L16) [[3]](diffhunk://#diff-045cd509b297435293d414d8dc24b88bc43e76f13772c8ca8d75aa81b54b4e71L34-L36)
- Added missing import of `Cake\Core\Configure` in `ImageServeHelper` for accessing variant configuration.

These changes collectively improve image delivery performance, browser compatibility, and maintainability of the codebase.