### PR TITLE
Implement image profiles for consistent URL generation and rendering

### DIFF
--- a/e2e/blog-featured-thumb.spec.js
+++ b/e2e/blog-featured-thumb.spec.js
@@ -47,6 +47,18 @@ test.describe("Blog featured thumb behavior", () => {
         const img = featuredPicture.locator("img").first();
 
         await expect(source).toHaveAttribute("srcset", /\/images\/serve\/\d+/);
+        await expect(source).toHaveAttribute("srcset", /profile=blog_featured/);
         await expect(img).toHaveAttribute("src", /\/images\/serve\/\d+/);
+        await expect(img).toHaveAttribute("src", /profile=blog_featured/);
+
+        const featuredListThumb = page
+            .locator(".blog-featured-as-list picture img")
+            .first();
+        if ((await featuredListThumb.count()) > 0) {
+            await expect(featuredListThumb).toHaveAttribute(
+                "src",
+                /profile=blog_index_card/,
+            );
+        }
     });
 });

--- a/e2e/blog-pages.spec.js
+++ b/e2e/blog-pages.spec.js
@@ -73,6 +73,13 @@ test.describe("Blog - Public Pages", () => {
                 // Check srcset includes fm=webp
                 const srcset = await webpSource.getAttribute('srcset');
                 expect(srcset).toContain('fm=webp');
+
+                // Public blog pages should use image profiles for featured/list cards
+                expect(srcset).toMatch(/profile=blog_(featured|index_card)/);
+
+                const fallbackImg = pictures.first().locator('img').first();
+                const imgSrc = await fallbackImg.getAttribute('src');
+                expect(imgSrc || '').toMatch(/profile=blog_(featured|index_card)/);
             }
         }
     });

--- a/e2e/seasons-image-profiles.spec.js
+++ b/e2e/seasons-image-profiles.spec.js
@@ -1,0 +1,38 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Season image profile URLs", () => {
+    test("season billboard and roster avatar images use profile-based routes", async ({ page }) => {
+        await page.goto("/seasons/1");
+        await page.waitForLoadState("networkidle");
+
+        const seasonHero = page.locator(".season-hero-image").first();
+        if ((await seasonHero.count()) > 0) {
+            await expect(seasonHero).toHaveAttribute("src", /profile=season_billboard/);
+            const heroSource = page
+                .locator(".season-hero-media picture source[type='image/webp']")
+                .first();
+            if ((await heroSource.count()) > 0) {
+                await expect(heroSource).toHaveAttribute(
+                    "srcset",
+                    /profile=season_billboard/,
+                );
+            }
+        }
+
+        const rosterAvatar = page
+            .locator("img.season-roster-avatar-img")
+            .first();
+        if ((await rosterAvatar.count()) > 0) {
+            await expect(rosterAvatar).toHaveAttribute("src", /profile=roster_avatar/);
+            const rosterSource = page
+                .locator(".season-roster-avatar picture source[type='image/webp']")
+                .first();
+            if ((await rosterSource.count()) > 0) {
+                await expect(rosterSource).toHaveAttribute(
+                    "srcset",
+                    /profile=roster_avatar/,
+                );
+            }
+        }
+    });
+});

--- a/src/Application.php
+++ b/src/Application.php
@@ -79,6 +79,31 @@ class Application extends BaseApplication implements
             'medium' => ['maxWidth' => 800, 'format' => 'webp'],
             'webp' => ['format' => 'webp'], // WebP alternate of original
         ]);
+
+        // Public image profiles for stable, semantic URLs backed by transforms.
+        // Profiles may optionally use a sourceVariant for custom-cropped inputs.
+        Configure::write('Images.profiles', [
+            'roster_avatar' => [
+                'sourceVariant' => 'thumb',
+                'w' => 150,
+                'h' => 150,
+                'fit' => 'cover',
+            ],
+            'season_billboard' => [
+                'w' => 1400,
+                'h' => 720,
+                'fit' => 'cover',
+            ],
+            'blog_featured' => [
+                'h' => 720,
+                'fit' => 'cover',
+            ],
+            'blog_index_card' => [
+                'w' => 200,
+                'h' => 150,
+                'fit' => 'cover',
+            ],
+        ]);
     }
 
     /**

--- a/src/Controller/ImagesController.php
+++ b/src/Controller/ImagesController.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use Cake\Core\Configure;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Http\Response;
 use Cake\Log\Log;
@@ -56,6 +57,7 @@ class ImagesController extends AppController
     /**
      * Public serve endpoint (no auth) for original or variant.
      * /images/serve/123?variant=thumb
+     * /images/serve/123?profile=roster_avatar
      *
      * @param int $id
      */
@@ -67,7 +69,10 @@ class ImagesController extends AppController
         if (!$image) {
             return $this->placeholderTransparentPng();
         }
-        $variant = (string)$request->getQuery('variant');
+        $profileName = strtolower((string)$request->getQuery('profile'));
+        $profileConfig = $this->getProfileConfig($profileName);
+
+        $variant = $this->resolveVariantForProfile((string)$request->getQuery('variant'), $profileConfig);
         [$path, $mime] = $this->resolvePath($image, $variant);
 
         if (!is_file($path)) {
@@ -76,16 +81,21 @@ class ImagesController extends AppController
 
         $cacheControl = 'public, max-age=3600, must-revalidate';
 
-        $etag = $this->buildEtag((string)($image->hash ?? ''), $variant, []);
+        $etagVariant = $variant;
+        if ($profileName !== '') {
+            $etagVariant .= '|profile:' . $profileName;
+        }
 
-        $transform = $this->extractTransformParams();
+        $etag = $this->buildEtag((string)($image->hash ?? ''), $etagVariant, []);
+
+        $transform = $this->extractTransformParams($profileConfig);
         if ($this->shouldAutoServeWebp($mime) && ($transform === null || !isset($transform['fm']))) {
             $transform ??= [];
             $transform['fm'] = 'webp';
         }
 
         if ($transform !== null) {
-            return $this->serveTransformed($image, $path, $mime, $variant, $transform, $cacheControl);
+            return $this->serveTransformed($image, $path, $mime, $etagVariant, $transform, $cacheControl);
         }
 
         $ifNoneMatch = $request->getHeaderLine('If-None-Match');
@@ -114,20 +124,23 @@ class ImagesController extends AppController
      *
      * Supported (Glide-like): w, h, fit (cover|contain), fm (jpg|png|webp), q (1..100)
      *
+     * Profile defaults (Images.profiles) are merged first, then overridden by explicit query params.
+     *
+     * @param array<string,mixed> $profileConfig
      * @return array<string,mixed>|null
      */
-    private function extractTransformParams(): ?array
+    private function extractTransformParams(array $profileConfig = []): ?array
     {
+        $out = $this->profileToTransformParams($profileConfig);
+
         $q = $this->getRequest()->getQueryParams();
-        unset($q['variant'], $q['v']);
+        unset($q['variant'], $q['v'], $q['profile']);
 
         $w = $q['w'] ?? null;
         $h = $q['h'] ?? null;
         $fit = strtolower((string)($q['fit'] ?? ''));
         $fm = strtolower((string)($q['fm'] ?? ''));
         $quality = $q['q'] ?? null;
-
-        $out = [];
 
         $width = is_numeric($w) ? (int)$w : null;
         $height = is_numeric($h) ? (int)$h : null;
@@ -158,6 +171,76 @@ class ImagesController extends AppController
         }
 
         return $out ?: null;
+    }
+
+    /**
+     * Resolve an image profile from app config.
+     *
+     * @param string $profileName
+     * @return array<string,mixed>
+     */
+    private function getProfileConfig(string $profileName): array
+    {
+        if ($profileName === '') {
+            return [];
+        }
+
+        $profiles = (array)Configure::read('Images.profiles', []);
+        $profileConfig = $profiles[$profileName] ?? null;
+
+        return is_array($profileConfig) ? $profileConfig : [];
+    }
+
+    /**
+     * Resolve effective variant for profile-backed requests.
+     *
+     * @param string $variant
+     * @param array<string,mixed> $profileConfig
+     */
+    private function resolveVariantForProfile(string $variant, array $profileConfig): string
+    {
+        if ($variant !== '') {
+            return $variant;
+        }
+
+        $sourceVariant = $profileConfig['sourceVariant'] ?? null;
+
+        return is_string($sourceVariant) ? $sourceVariant : '';
+    }
+
+    /**
+     * Convert a profile config into validated transform parameters.
+     *
+     * @param array<string,mixed> $profileConfig
+     * @return array<string,mixed>
+     */
+    private function profileToTransformParams(array $profileConfig): array
+    {
+        $out = [];
+
+        $w = $profileConfig['w'] ?? null;
+        $h = $profileConfig['h'] ?? null;
+        $fit = strtolower((string)($profileConfig['fit'] ?? ''));
+        $fm = strtolower((string)($profileConfig['fm'] ?? ''));
+        $q = $profileConfig['q'] ?? null;
+
+        if (is_numeric($w) && (int)$w > 0) {
+            $out['w'] = (int)$w;
+        }
+        if (is_numeric($h) && (int)$h > 0) {
+            $out['h'] = (int)$h;
+        }
+        if ($fit !== '' && in_array($fit, ['cover', 'contain'], true)) {
+            $out['fit'] = $fit;
+        }
+        if ($fm !== '' && in_array($fm, ['jpg', 'jpeg', 'png', 'webp'], true)) {
+            $out['fm'] = $fm === 'jpeg' ? 'jpg' : $fm;
+        }
+        if (is_numeric($q)) {
+            $out['q'] = max(1, min(100, (int)$q));
+        }
+
+        return $out;
     }
 
     /**

--- a/src/View/Helper/ImageServeHelper.php
+++ b/src/View/Helper/ImageServeHelper.php
@@ -12,6 +12,7 @@ use Cake\View\Helper;
  * Centralizes building `/images/serve/:id` URLs with common query params:
  * - w, h, fit, fm, q
  * - variant
+ * - profile
  */
 class ImageServeHelper extends Helper
 {
@@ -83,7 +84,7 @@ class ImageServeHelper extends Helper
      * Supports responsive srcset for multiple sizes on different breakpoints.
      *
      * @param object|string|int $image Image ID or Image entity
-     * @param array<string, mixed> $params URL parameters (w, h, fit, etc.)
+     * @param array<string, mixed> $params URL parameters (w, h, fit, variant, profile, etc.)
      * @param array<string, mixed> $attrs HTML attributes for the <img> element
      * @return string HTML picture element
      */
@@ -349,7 +350,7 @@ class ImageServeHelper extends Helper
      */
     private function filterParams(array $params): array
     {
-        $allowed = ['w', 'h', 'fit', 'fm', 'q', 'variant', '_ts'];
+        $allowed = ['w', 'h', 'fit', 'fm', 'q', 'profile', 'variant', '_ts'];
         $out = [];
 
         foreach ($allowed as $key) {

--- a/templates/Seasons/view.php
+++ b/templates/Seasons/view.php
@@ -103,7 +103,7 @@ $this->start('css'); ?>
         <div class="season-hero-media mb-4">
             <?= $this->ImageServe->picture(
                 (int)$heroImageId,
-                ['w' => 1400, 'h' => 720, 'fit' => 'cover'],
+                ['profile' => 'season_billboard'],
                 [
                     'alt' => $teamName . ' ' . $seasonLabel . ' Season',
                     'class' => 'img-fluid rounded season-hero-image',
@@ -369,6 +369,7 @@ $this->start('css'); ?>
                                             <?= $this->element('person_image', [
                                                 'person' => $person,
                                                 'size' => 'small',
+                                                'profile' => 'roster_avatar',
                                                 'class' => 'season-roster-avatar-img',
                                                 'style' => 'width: 72px; height: 72px;',
                                             ]) ?>

--- a/templates/element/blog/index_frame.php
+++ b/templates/element/blog/index_frame.php
@@ -48,7 +48,7 @@ if ($page === 1 && !empty($posts)) {
                         <?= $this->ImageServe->responsivePicture(
                             $featured->hero_image_id,
                             [600, 900, 1200],
-                            ['fit' => 'cover', 'h' => 720],
+                            ['profile' => 'blog_featured'],
                             [
                                 'alt' => h($featured->title),
                                 'class' => 'img-fluid rounded blog-hero-image',
@@ -65,7 +65,7 @@ if ($page === 1 && !empty($posts)) {
                     <figure style="flex-shrink: 0; width: 120px; height: 90px; margin: 0;">
                         <?= $this->ImageServe->picture(
                             $featured->hero_image_id,
-                            ['w' => 200, 'h' => 150, 'fit' => 'cover'],
+                            ['profile' => 'blog_index_card'],
                             [
                                 'alt' => h($featured->title),
                                 'class' => 'img-fluid rounded',

--- a/templates/element/blog/list_items.php
+++ b/templates/element/blog/list_items.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
         <figure style="flex-shrink: 0; width: 120px; height: 90px; margin: 0;">
             <?= $this->ImageServe->picture(
                 $post->hero_image_id,
-                ['w' => 200, 'h' => 150, 'fit' => 'cover'],
+                ['profile' => 'blog_index_card'],
                 [
                     'alt' => h($post->title),
                     'class' => 'img-fluid rounded',

--- a/templates/element/person_image.php
+++ b/templates/element/person_image.php
@@ -7,6 +7,7 @@
  * Variables:
  * - $person: Person entity with person_image field
  * - $size: Optional size ('small', 'medium', 'large') - defaults to 'medium'
+ * - $profile: Optional image profile to use
  * - $variant: Optional image variant to use (e.g., 'thumb', 'medium')
  * - $class: Optional CSS classes
  * - $style: Optional inline styles
@@ -16,6 +17,7 @@
  */
 
 $size = $size ?? 'medium';
+$profile = $profile ?? null;
 $variant = $variant ?? 'thumb';
 $class = $class ?? '';
 $style = $style ?? '';
@@ -38,9 +40,16 @@ $cssStyle = "width: {$width}px; height: {$height}px; object-fit: cover; border-r
 
 // Build image URL
 if (!empty($person->person_image) && is_numeric($person->person_image)) {
+    $imageParams = [];
+    if (is_string($profile) && $profile !== '') {
+        $imageParams['profile'] = $profile;
+    } elseif (is_string($variant) && $variant !== '') {
+        $imageParams['variant'] = $variant;
+    }
+
     echo $this->ImageServe->picture(
         (int)$person->person_image,
-        ['variant' => $variant],
+        $imageParams,
         [
             'alt' => (string)($person->display ?? $person->first . ' ' . $person->last),
             'class' => $cssClass,

--- a/tests/TestCase/Controller/BlogControllerTest.php
+++ b/tests/TestCase/Controller/BlogControllerTest.php
@@ -29,7 +29,8 @@ class BlogControllerTest extends TestCase
         $this->assertResponseOk();
         $this->assertResponseContains('<turbo-frame id="blog">');
         $this->assertResponseContains('blog-featured-as-list');
-        $this->assertResponseContains('/images/serve/1?w=200&amp;h=150&amp;fit=cover');
+        $this->assertResponseContains('profile=blog_featured');
+        $this->assertResponseContains('profile=blog_index_card');
         $this->assertResponseContains('fm=webp');
     }
 

--- a/tests/TestCase/Controller/ImagesControllerTest.php
+++ b/tests/TestCase/Controller/ImagesControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace App\Test\TestCase\Controller;
 
 use App\Controller\ImagesController;
+use Cake\Core\Configure;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\ORM\TableRegistry;
@@ -304,6 +305,108 @@ class ImagesControllerTest extends TestCase
             'fm' => 'jpg',
             'q' => 100,
         ], $method->invoke($controller));
+    }
+
+    /**
+     * Tests profile transform defaults merge with explicit query overrides.
+     */
+    public function testExtractTransformParamsMergesProfileDefaultsAndQueryOverrides(): void
+    {
+        $previousProfiles = Configure::read('Images.profiles');
+        Configure::write('Images.profiles', [
+            'roster_avatar' => [
+                'w' => 150,
+                'h' => 150,
+                'fit' => 'cover',
+            ],
+        ]);
+
+        $controller = $this->createImagesControllerWithQuery([
+            'profile' => 'roster_avatar',
+            'w' => '72',
+            'q' => '150',
+        ]);
+        try {
+            $getProfile = $this->getPrivateMethod($controller, 'getProfileConfig');
+            $profileConfig = $getProfile->invoke($controller, 'roster_avatar');
+            $method = $this->getPrivateMethod($controller, 'extractTransformParams');
+
+            $this->assertSame([
+                'w' => 72,
+                'h' => 150,
+                'fit' => 'cover',
+                'q' => 100,
+            ], $method->invoke($controller, $profileConfig));
+        } finally {
+            Configure::write('Images.profiles', $previousProfiles);
+        }
+    }
+
+    /**
+     * Tests profile config lookup returns empty array for unknown profile.
+     */
+    public function testGetProfileConfigReturnsEmptyForUnknownProfile(): void
+    {
+        $controller = $this->createImagesControllerWithQuery();
+        $method = $this->getPrivateMethod($controller, 'getProfileConfig');
+
+        $this->assertSame([], $method->invoke($controller, 'does-not-exist'));
+    }
+
+    /**
+     * Tests profile source variant resolution honors explicit variant.
+     */
+    public function testResolveVariantForProfileHonorsExplicitVariant(): void
+    {
+        $controller = $this->createImagesControllerWithQuery();
+        $method = $this->getPrivateMethod($controller, 'resolveVariantForProfile');
+
+        $this->assertSame(
+            'medium',
+            $method->invoke($controller, 'medium', ['sourceVariant' => 'thumb']),
+        );
+        $this->assertSame(
+            'thumb',
+            $method->invoke($controller, '', ['sourceVariant' => 'thumb']),
+        );
+    }
+
+    /**
+     * Tests serve with profile applies configured transforms and profile-scoped ETag.
+     */
+    public function testServeWithProfileAppliesConfiguredTransforms(): void
+    {
+        $previousProfiles = Configure::read('Images.profiles');
+        Configure::write('Images.profiles', [
+            'blog_index_card' => [
+                'w' => 200,
+                'h' => 150,
+                'fit' => 'cover',
+            ],
+        ]);
+
+        $png = $this->tinyPngBytes();
+        $fullPath = $this->writeFixtureImageFile(1, $png);
+
+        try {
+            $this->get('/images/serve/1?profile=blog_index_card');
+            $this->assertResponseOk();
+            $contentType = $this->_response->getHeaderLine('Content-Type');
+            $this->assertContains($contentType, ['image/webp', 'image/png']);
+
+            $images = TableRegistry::getTableLocator()->get('Images');
+            $image = $images->get(1);
+            $expected = $this->computeEtag(
+                (string)$image->get('hash'),
+                '|profile:blog_index_card',
+                ['w' => 200, 'h' => 150, 'fit' => 'cover', 'fm' => 'webp'],
+            );
+
+            $this->assertSame($expected, $this->_response->getHeaderLine('ETag'));
+        } finally {
+            $this->safeUnlink($fullPath);
+            Configure::write('Images.profiles', $previousProfiles);
+        }
     }
 
     /**

--- a/tests/TestCase/Controller/SeasonsControllerTest.php
+++ b/tests/TestCase/Controller/SeasonsControllerTest.php
@@ -223,4 +223,30 @@ class SeasonsControllerTest extends TestCase
         sort($sorted);
         $this->assertSame($sorted, $dates, 'Games should be sorted by date ascending');
     }
+
+    /**
+     * Tests season view uses profile-based image URLs for billboards and roster avatars.
+     */
+    public function testViewUsesProfileBasedImageUrls(): void
+    {
+        $this->get('/seasons/1');
+        $this->assertResponseOk();
+
+        $teamSeason = $this->viewVariable('teamSeason');
+        if (!empty($teamSeason?->team_season_image)) {
+            $this->assertResponseContains('profile=season_billboard');
+        }
+
+        $roster = $this->viewVariable('roster');
+        $hasRosterImage = false;
+        foreach ($roster as $entry) {
+            if (!empty($entry?->person?->person_image)) {
+                $hasRosterImage = true;
+                break;
+            }
+        }
+        if ($hasRosterImage) {
+            $this->assertResponseContains('profile=roster_avatar');
+        }
+    }
 }

--- a/tests/TestCase/View/Helper/ImageServeHelperTest.php
+++ b/tests/TestCase/View/Helper/ImageServeHelperTest.php
@@ -50,6 +50,7 @@ class ImageServeHelperTest extends TestCase
             'w' => 150,
             'h' => '150',
             'fit' => 'cover',
+            'profile' => 'roster_avatar',
             'variant' => 'thumb',
             'q' => 90,
             'v' => 'ignored-version',
@@ -64,6 +65,7 @@ class ImageServeHelperTest extends TestCase
         $this->assertSame('150', (string)$parsed['w']);
         $this->assertSame('150', (string)$parsed['h']);
         $this->assertSame('cover', $parsed['fit']);
+        $this->assertSame('roster_avatar', $parsed['profile']);
         $this->assertSame('thumb', $parsed['variant']);
         $this->assertSame('90', (string)$parsed['q']);
         $this->assertArrayNotHasKey('bogus', $parsed);
@@ -210,6 +212,17 @@ class ImageServeHelperTest extends TestCase
     }
 
     /**
+     * Tests picture keeps profile parameter for both source and fallback URLs.
+     */
+    public function testPictureWithProfileIncludesProfileInUrls(): void
+    {
+        $html = $this->helper->picture(42, ['profile' => 'roster_avatar']);
+
+        $this->assertStringContainsString('/images/serve/42?fm=webp&amp;profile=roster_avatar', $html);
+        $this->assertStringContainsString('/images/serve/42?profile=roster_avatar', $html);
+    }
+
+    /**
      * Tests picture handles special characters in alt.
      */
     public function testPictureHandlesSpecialCharactersInAlt(): void
@@ -321,6 +334,21 @@ class ImageServeHelperTest extends TestCase
 
         $this->assertStringContainsString('fit=cover', $html);
         $this->assertStringContainsString('q=80', $html);
+    }
+
+    /**
+     * Tests responsive picture retains profile parameter across generated srcset URLs.
+     */
+    public function testResponsivePictureWithProfileIncludesProfileAcrossSrcset(): void
+    {
+        $html = $this->helper->responsivePicture(
+            12,
+            [400, 800],
+            ['profile' => 'blog_featured'],
+        );
+
+        $this->assertStringContainsString('profile=blog_featured', $html);
+        $this->assertStringContainsString('fm=webp', $html);
     }
 
     /**

--- a/webroot/js/tests/image-profile-markup.test.mjs
+++ b/webroot/js/tests/image-profile-markup.test.mjs
@@ -1,0 +1,36 @@
+/** @jest-environment node */
+
+import { describe, test, expect } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const readTemplate = (...parts) =>
+    readFileSync(join(process.cwd(), ...parts), "utf8");
+
+describe("Hybrid image profile markup", () => {
+    test("season view markup uses profile routes for billboard and roster avatar", () => {
+        const seasonView = readTemplate("templates", "Seasons", "view.php");
+
+        expect(seasonView).toContain("profile' => 'season_billboard'");
+        expect(seasonView).toContain("'profile' => 'roster_avatar'");
+    });
+
+    test("blog index templates use profile routes for featured and card images", () => {
+        const indexFrame = readTemplate(
+            "templates",
+            "element",
+            "blog",
+            "index_frame.php",
+        );
+        const listItems = readTemplate(
+            "templates",
+            "element",
+            "blog",
+            "list_items.php",
+        );
+
+        expect(indexFrame).toContain("profile' => 'blog_featured'");
+        expect(indexFrame).toContain("profile' => 'blog_index_card'");
+        expect(listItems).toContain("profile' => 'blog_index_card'");
+    });
+});

--- a/webroot/js/tests/season.view.css.test.mjs
+++ b/webroot/js/tests/season.view.css.test.mjs
@@ -30,6 +30,19 @@ describe("Season view CSS", () => {
         );
     });
 
+    test("season hero image keeps cover layout", () => {
+        expect(css).toMatch(/\.season-hero-image[\s\S]*object-fit:\s*cover/i);
+        expect(css).toMatch(/\.season-hero-image[\s\S]*max-height:\s*480px/i);
+    });
+
+    test("season roster avatar image keeps circular crop", () => {
+        expect(css).toMatch(
+            /\.season-roster-avatar-img[\s\S]*border-radius:\s*50%/i,
+        );
+        expect(css).toMatch(/\.season-roster-avatar-img[\s\S]*width:\s*72px/i);
+        expect(css).toMatch(/\.season-roster-avatar-img[\s\S]*height:\s*72px/i);
+    });
+
     test("dark mode season games table links use readable link colour", () => {
         // Both [data-theme=dark] and prefers-color-scheme:dark must set --rh-link
         expect(css).toMatch(


### PR DESCRIPTION
This pull request introduces a new "image profiles" system for generating stable, semantic image URLs with pre-configured transforms, and updates the application to use these profiles for blog, season, and roster images. The main changes include adding image profile definitions in configuration, updating the image serving controller to support profile-based requests, and refactoring templates and tests to use the new profile query parameter instead of explicit transform parameters.

**Image profile system and controller enhancements:**

* Added a new `Images.profiles` configuration in `Application.php` defining image profiles (e.g., `roster_avatar`, `season_billboard`, `blog_featured`, `blog_index_card`) with their transform parameters.
* Enhanced `ImagesController` to support a `profile` query parameter on the `/images/serve/:id` endpoint, resolving transform parameters from the profile, merging with query overrides, and updating ETag generation for cache correctness. [[1]](diffhunk://#diff-640368c08b70aa36779c1c5cae4c68b1d78a150bc4e44365ce02f05e861aebf1L70-R75) [[2]](diffhunk://#diff-640368c08b70aa36779c1c5cae4c68b1d78a150bc4e44365ce02f05e861aebf1L79-R98) [[3]](diffhunk://#diff-640368c08b70aa36779c1c5cae4c68b1d78a150bc4e44365ce02f05e861aebf1R127-L131) [[4]](diffhunk://#diff-640368c08b70aa36779c1c5cae4c68b1d78a150bc4e44365ce02f05e861aebf1R176-R245)
* Updated `ImageServeHelper` to allow building image URLs with the `profile` parameter and to filter/allow it as a valid param. [[1]](diffhunk://#diff-469e19c5405f0e02232ef3a21ed31892f5b499b88454f21e1c0dc93374bc9d76R15) [[2]](diffhunk://#diff-469e19c5405f0e02232ef3a21ed31892f5b499b88454f21e1c0dc93374bc9d76L86-R87) [[3]](diffhunk://#diff-469e19c5405f0e02232ef3a21ed31892f5b499b88454f21e1c0dc93374bc9d76L352-R353)

**Template and usage updates:**

* Refactored blog and season templates to use the new `profile` parameter instead of explicit width/height/fit for images. This ensures consistent image sizing and easier updates. [[1]](diffhunk://#diff-60c4be12afceb99d52ee63f08c7d8a6cf3b501e0911598ffe60a6b5861b3a6bbL106-R106) [[2]](diffhunk://#diff-60c4be12afceb99d52ee63f08c7d8a6cf3b501e0911598ffe60a6b5861b3a6bbR372) [[3]](diffhunk://#diff-dd6773b0e8c6597c5dfeb36bb244a1b0a8290b3278054f6709fd05f9be9d1c07L51-R51) [[4]](diffhunk://#diff-dd6773b0e8c6597c5dfeb36bb244a1b0a8290b3278054f6709fd05f9be9d1c07L68-R68) [[5]](diffhunk://#diff-318c7a573b3ebe6922cfb58bf699b302aed75af1491fcbeaf4da6841c538a0ecL24-R24) [[6]](diffhunk://#diff-c27da73b9d5fb22d50f808e5ce840900dfa35058278d5b2fd41a8b4b2ff7fa6fR10) [[7]](diffhunk://#diff-c27da73b9d5fb22d50f808e5ce840900dfa35058278d5b2fd41a8b4b2ff7fa6fR20) [[8]](diffhunk://#diff-c27da73b9d5fb22d50f808e5ce840900dfa35058278d5b2fd41a8b4b2ff7fa6fR43-R52)
* Updated the `person_image` element to accept and forward the `profile` parameter. [[1]](diffhunk://#diff-c27da73b9d5fb22d50f808e5ce840900dfa35058278d5b2fd41a8b4b2ff7fa6fR10) [[2]](diffhunk://#diff-c27da73b9d5fb22d50f808e5ce840900dfa35058278d5b2fd41a8b4b2ff7fa6fR20) [[3]](diffhunk://#diff-c27da73b9d5fb22d50f808e5ce840900dfa35058278d5b2fd41a8b4b2ff7fa6fR43-R52)

**Test coverage and new tests:**

* Added and updated end-to-end tests to verify that the correct `profile` parameters are present in image URLs for blog, season, and roster images. [[1]](diffhunk://#diff-6d871e3c404a4fbc819aeed05befccf695fd84c1d98b6bfca59901f32fa2c80eR50-R62) [[2]](diffhunk://#diff-4e07ae0878d471573728dec454dd88f857c8371a0c24e150ad37c7f116627d84R76-R82) [[3]](diffhunk://#diff-b799d218965abdc5fcd6949362755d6a7ee119b2145087052a3f504e7d7c0064R1-R38)
* Updated controller and integration tests to expect the new profile-based URLs and parameters. [[1]](diffhunk://#diff-3e56050e1fb352f2911988c651a5f5fda5077e5795de04a78674de95f31b9637L32-R33) [[2]](diffhunk://#diff-a387eedd2c3180578171b271d12986968e01590c44ee28ed2d2dfc7ab0277172R7)

These changes lay the groundwork for consistent, maintainable image sizing and transformation across the app, making it easier to update image styles in one place and improving cacheability and semantics of image URLs.