### PR TITLE
Update image serving and switch placeholder to WebP format

### DIFF
--- a/src/Controller/Admin/ImagesController.php
+++ b/src/Controller/Admin/ImagesController.php
@@ -111,8 +111,8 @@ class ImagesController extends AppController
     }
 
     /**
-     * Serve an image (original or variant) by id and optional variant name.
-     * Example: /admin/images/serve/123?variant=thumb
+     * Compatibility endpoint that delegates image serving to the public controller.
+     * Example: /admin/images/serve/123?variant=thumb -> /images/serve/123?variant=thumb
      *
      * @param int $id
      */
@@ -120,46 +120,10 @@ class ImagesController extends AppController
     {
         $request = $this->getRequest();
         $request->allowMethod(['get', 'head']);
-        $variant = (string)$request->getQuery('variant');
-        // Support legacy query-based sizing by mapping to a prebuilt variant.
-        // If callers pass w/h/fit without an explicit variant, serve the "thumb".
-        if ($variant === '') {
-            $w = $request->getQuery('w');
-            $h = $request->getQuery('h');
-            $fit = $request->getQuery('fit');
-            if ($w !== null || $h !== null || $fit !== null) {
-                $variant = 'thumb';
-            }
-        }
+        $params = $request->getQueryParams();
+        $query = $params === [] ? '' : '?' . http_build_query($params);
 
-        $storage = new ImageStorageService();
-        $image = $storage->loadImageOrFail($id);
-        [$path, $mime] = $storage->resolveImagePath($image, $variant);
-
-        Log::debug("Serve image #{$id}, variant: '{$variant}', path: {$path}, mime: {$mime}");
-        if (is_file($path)) {
-            Log::debug("File exists at {$path}, size: " . filesize($path) . ' bytes');
-        } else {
-            Log::debug("File NOT found at {$path}");
-        }
-
-        $contents = is_file($path)
-            ? (file_get_contents($path) ?: '')
-            : '';
-        if ($contents === '') {
-            // Graceful fallback: return a 1x1 transparent PNG instead of 404 to avoid broken icons in editor/content.
-            return $this->placeholderTransparentPng();
-        }
-
-        // Add cache-busting headers
-        $response = $this->getResponse()
-            ->withType($mime)
-            ->withStringBody($contents)
-            ->withHeader('Cache-Control', 'no-cache, no-store, must-revalidate, max-age=0')
-            ->withHeader('Pragma', 'no-cache')
-            ->withHeader('Expires', 'Thu, 01 Jan 1970 00:00:00 GMT');
-
-        return $response;
+        return $this->redirect('/images/serve/' . $id . $query);
     }
 
     /**
@@ -795,25 +759,6 @@ class ImagesController extends AppController
     }
 
     /**
-     * Return a 1x1 transparent PNG response (base64 inline data) used as a safe placeholder.
-     */
-    private function placeholderTransparentPng(): Response
-    {
-        // Single pixel transparent PNG
-        $data = base64_decode(
-            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMA' .
-            'AQAABQABDQottAAAAABJRU5ErkJggg==',
-        );
-
-        return $this->getResponse()
-            ->withType('image/png')
-            ->withHeader('Cache-Control', 'no-cache, no-store, must-revalidate, max-age=0')
-            ->withHeader('Pragma', 'no-cache')
-            ->withHeader('Expires', 'Thu, 01 Jan 1970 00:00:00 GMT')
-            ->withStringBody($data ?: '');
-    }
-
-    /**
      * Serialize image entity for JSON response.
      *
      * @param \App\Model\Entity\Image $image
@@ -829,9 +774,10 @@ class ImagesController extends AppController
         if (is_array($raw)) {
             $variants = $raw;
         }
-        // Provide signed/parameterized URL (for now simple route) to serve original
-        $baseUrl = '/admin/images/serve/' . $image->id;
+        // `url` is the canonical public serving endpoint; keep admin_url for legacy callers.
         $publicServeUrl = '/images/serve/' . $image->id;
+        $baseUrl = $publicServeUrl;
+        $adminServeUrl = '/admin/images/serve/' . $image->id;
         $directUrl = '/img/storage/' .
             ltrim($image->storage_path ?? ($image->storage_subdir . '/' . $image->filename), '/');
 
@@ -839,6 +785,7 @@ class ImagesController extends AppController
             'id' => $image->id,
             'filename' => $image->filename,
             'url' => $baseUrl,
+            'admin_url' => $adminServeUrl,
             'variants' => $variants,
             'direct_url' => $directUrl,
             'public_url' => $publicServeUrl,

--- a/src/Controller/ImagesController.php
+++ b/src/Controller/ImagesController.php
@@ -67,7 +67,7 @@ class ImagesController extends AppController
         $request->allowMethod(['get', 'head']);
         $image = $this->fetchTable('Images')->find()->where(['id' => $id])->first();
         if (!$image) {
-            return $this->placeholderTransparentPng();
+            return $this->placeholderTransparentWebp();
         }
         $profileName = strtolower((string)$request->getQuery('profile'));
         $profileConfig = $this->getProfileConfig($profileName);
@@ -76,7 +76,7 @@ class ImagesController extends AppController
         [$path, $mime] = $this->resolvePath($image, $variant);
 
         if (!is_file($path)) {
-            return $this->placeholderTransparentPng();
+            return $this->placeholderTransparentWebp();
         }
 
         $cacheControl = 'public, max-age=3600, must-revalidate';
@@ -108,7 +108,7 @@ class ImagesController extends AppController
 
         $body = file_get_contents($path) ?: '';
         if ($body === '') {
-            return $this->placeholderTransparentPng();
+            return $this->placeholderTransparentWebp();
         }
 
         return $this->getResponse()
@@ -295,7 +295,7 @@ class ImagesController extends AppController
             $manager = extension_loaded('imagick') ? ImageManager::imagick() : ImageManager::gd();
             $raw = file_get_contents($path) ?: '';
             if ($raw === '') {
-                return $this->placeholderTransparentPng();
+                return $this->placeholderTransparentWebp();
             }
 
             $img = $manager->read($raw);
@@ -317,7 +317,7 @@ class ImagesController extends AppController
                 : $img->encodeByMediaType($outMime);
             $body = (string)$encoded;
             if ($body === '') {
-                return $this->placeholderTransparentPng();
+                return $this->placeholderTransparentWebp();
             }
 
             $this->atomicWriteCache($cached, $body);
@@ -331,7 +331,7 @@ class ImagesController extends AppController
             // Degrade gracefully to original bytes if transform fails.
             $body = file_get_contents($path) ?: '';
             if ($body === '') {
-                return $this->placeholderTransparentPng();
+                return $this->placeholderTransparentWebp();
             }
 
             return $this->getResponse()
@@ -470,16 +470,18 @@ class ImagesController extends AppController
     }
 
     /**
-     * Return a 1x1 transparent PNG Response used as a safe placeholder.
+     * Return a 1x1 transparent WebP Response used as a safe placeholder.
      */
-    private function placeholderTransparentPng(): Response
+    private function placeholderTransparentWebp(): Response
     {
-        $b64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMA'
-            . 'AQAABQABDQottAAAAABJRU5ErkJggg==';
+        $b64 = 'UklGRkoAAABXRUJQVlA4WAoAAAAQAAAAAAAAAAAAQUxQSAwAAAARBxAR/QERFA0B' .
+           'VlA4WQoAAAAcAAAASUNDUAAREAAAbW50clJHQiBYWVogAAAAAAAAAAAAAAAAMVdQ' .
+           'S0AnAAAAAAAAAAAANmYAAHAGAABwYwAAZgAAVTRSTAAUAAAAAAAAAAAAAAAAAAAA' .
+           'AAAAAAA=';
         $data = base64_decode($b64);
 
         return $this->getResponse()
-            ->withType('image/png')
+            ->withType('image/webp')
             ->withHeader('Cache-Control', 'no-cache, no-store, must-revalidate, max-age=0')
             ->withHeader('Pragma', 'no-cache')
             ->withHeader('Expires', 'Thu, 01 Jan 1970 00:00:00 GMT')

--- a/templates/Admin/Images/crop_thumb.php
+++ b/templates/Admin/Images/crop_thumb.php
@@ -37,6 +37,9 @@ $this->assign('title', 'Crop Thumbnail');
                             [
                                 'id' => 'crop-image',
                                 'alt' => (string)$image->original_name,
+                                'loading' => 'eager',
+                                'decoding' => 'sync',
+                                'fetchpriority' => 'high',
                                 'style' => 'display: block; max-width: 100%; height: auto; cursor: crosshair;',
                             ],
                         ) ?>

--- a/tests/TestCase/Controller/Admin/ImagesControllerMoreTest.php
+++ b/tests/TestCase/Controller/Admin/ImagesControllerMoreTest.php
@@ -371,15 +371,19 @@ class ImagesControllerMoreTest extends TestCase
     }
 
     /**
-     * Tests serve legacy sizing query maps to thumb variant.
+     * Tests admin serve preserves legacy sizing query when delegating to public serve.
      */
-    public function testServeLegacySizingQueryMapsToThumbVariant(): void
+    public function testServeLegacySizingQueryDelegatesToPublicServe(): void
     {
         $this->mockIdentity();
 
         $this->get('/admin/images/serve/1?w=300&h=300&fit=cover');
-        $this->assertResponseOk();
-        $this->assertSame('image/png', $this->_response->getHeaderLine('Content-Type'));
+        $this->assertRedirectContains('/images/serve/1');
+
+        $location = $this->_response->getHeaderLine('Location');
+        $this->assertStringContainsString('w=300', $location);
+        $this->assertStringContainsString('h=300', $location);
+        $this->assertStringContainsString('fit=cover', $location);
     }
 
     /**

--- a/tests/TestCase/Controller/Admin/ImagesControllerTest.php
+++ b/tests/TestCase/Controller/Admin/ImagesControllerTest.php
@@ -220,7 +220,7 @@ class ImagesControllerTest extends TestCase
     }
 
     /**
-     * Tests serve original and variant.
+     * Tests admin serve endpoint redirects original and variant requests to public serve.
      */
     public function testServeOriginalAndVariant(): void
     {
@@ -241,35 +241,40 @@ class ImagesControllerTest extends TestCase
         $json = json_decode((string)$this->_response->getBody(), true);
         $this->assertTrue($json['success'] ?? false, 'Upload should succeed');
         $id = $json['image']['id'];
-        // Serve original
+
+        // Admin endpoint delegates to the public image endpoint.
         $this->get('/admin/images/serve/' . $id);
+        $this->assertRedirectContains('/images/serve/' . $id);
+
+        // Confirm public endpoint serves image content.
+        $this->get('/images/serve/' . $id);
         $this->assertResponseOk();
-        $this->assertSame('image/png', $this->_response->getHeaderLine('Content-Type'));
-        $originalBody = (string)$this->_response->getBody();
-        $this->assertNotEmpty($originalBody, 'Original image body expected');
-        // Attempt to serve thumb variant (if generated)
+        $this->assertStringStartsWith('image/', $this->_response->getHeaderLine('Content-Type'));
+        $this->assertNotEmpty((string)$this->_response->getBody(), 'Original image body expected');
+
+        // Variant requests are delegated with query string intact.
         $this->get('/admin/images/serve/' . $id . '?variant=thumb');
-        if ($this->_response->getStatusCode() === 200) {
-            $variantBody = (string)$this->_response->getBody();
-            $this->assertNotEmpty($variantBody, 'Variant body expected');
-        }
+        $this->assertRedirectContains('/images/serve/' . $id . '?variant=thumb');
     }
 
     /**
-     * Tests serve missing file falls back to transparent png.
+     * Tests admin serve redirects to the public endpoint for fallback handling.
      */
-    public function testServeMissingFileFallsBackToTransparentPng(): void
+    public function testServeMissingFileRedirectsToPublicEndpoint(): void
     {
         $this->mockIdentity();
         // From fixture we have id=1 but no actual file on disk.
         $this->get('/admin/images/serve/1');
+        $this->assertRedirectContains('/images/serve/1');
+
+        $this->get('/images/serve/1');
         $this->assertResponseOk();
-        $this->assertSame('image/png', $this->_response->getHeaderLine('Content-Type'));
+        $this->assertSame('image/webp', $this->_response->getHeaderLine('Content-Type'));
         $this->assertStringContainsString('no-store', $this->_response->getHeaderLine('Cache-Control'));
         $body = (string)$this->_response->getBody();
-        $this->assertNotEmpty($body, 'Placeholder PNG should have content');
-        // Validate it looks like a PNG: starts with PNG signature bytes
-        $this->assertSame("\x89PNG", substr($body, 0, 4), 'Should start with PNG signature');
+        $this->assertNotEmpty($body, 'Placeholder WebP should have content');
+        $this->assertSame('RIFF', substr($body, 0, 4), 'Should start with RIFF signature');
+        $this->assertSame('WEBP', substr($body, 8, 4), 'Should identify as WEBP');
     }
 
     /**
@@ -280,7 +285,7 @@ class ImagesControllerTest extends TestCase
         // No auth needed for public route
         $this->get('/images/serve/1');
         $this->assertResponseOk();
-        $this->assertSame('image/png', $this->_response->getHeaderLine('Content-Type'));
+        $this->assertSame('image/webp', $this->_response->getHeaderLine('Content-Type'));
     }
 
     /**
@@ -345,7 +350,7 @@ class ImagesControllerTest extends TestCase
         // Trigger the transform code path.
         $this->get('/images/serve/' . $id . '?w=1&h=1&fit=cover&fm=png&q=90');
         $this->assertResponseOk();
-        $this->assertSame('image/png', $this->_response->getHeaderLine('Content-Type'));
+        $this->assertSame('image/webp', $this->_response->getHeaderLine('Content-Type'));
         $this->assertNotEmpty((string)$this->_response->getBody());
     }
 
@@ -430,7 +435,7 @@ class ImagesControllerTest extends TestCase
         // record 1 exists but has no variants, request a non-existent variant
         $this->get('/images/serve/1?variant=thumb');
         $this->assertResponseOk();
-        $this->assertSame('image/png', $this->_response->getHeaderLine('Content-Type'), 'Fallback should be PNG');
+        $this->assertSame('image/webp', $this->_response->getHeaderLine('Content-Type'), 'Fallback should be WebP');
         $this->assertStringContainsString('no-store', $this->_response->getHeaderLine('Cache-Control'));
     }
 

--- a/tests/TestCase/Controller/ImagesControllerTest.php
+++ b/tests/TestCase/Controller/ImagesControllerTest.php
@@ -58,33 +58,35 @@ class ImagesControllerTest extends TestCase
     }
 
     /**
-     * Tests serve missing record returns placeholder png.
+     * Tests serve missing record returns placeholder webp.
      */
-    public function testServeMissingRecordReturnsPlaceholderPng(): void
+    public function testServeMissingRecordReturnsPlaceholderWebp(): void
     {
         $this->get('/images/serve/999999');
         $this->assertResponseOk();
-        $this->assertSame('image/png', $this->_response->getHeaderLine('Content-Type'));
+        $this->assertSame('image/webp', $this->_response->getHeaderLine('Content-Type'));
         $this->assertStringContainsString('no-store', $this->_response->getHeaderLine('Cache-Control'));
 
         $body = (string)$this->_response->getBody();
         $this->assertNotEmpty($body);
-        $this->assertSame("\x89PNG", substr($body, 0, 4));
+        $this->assertSame('RIFF', substr($body, 0, 4));
+        $this->assertSame('WEBP', substr($body, 8, 4));
     }
 
     /**
-     * Tests serve missing file returns placeholder png.
+     * Tests serve missing file returns placeholder webp.
      */
-    public function testServeMissingFileReturnsPlaceholderPng(): void
+    public function testServeMissingFileReturnsPlaceholderWebp(): void
     {
         $this->get('/images/serve/1');
         $this->assertResponseOk();
-        $this->assertSame('image/png', $this->_response->getHeaderLine('Content-Type'));
+        $this->assertSame('image/webp', $this->_response->getHeaderLine('Content-Type'));
         $this->assertStringContainsString('no-store', $this->_response->getHeaderLine('Cache-Control'));
 
         $body = (string)$this->_response->getBody();
         $this->assertNotEmpty($body);
-        $this->assertSame("\x89PNG", substr($body, 0, 4));
+        $this->assertSame('RIFF', substr($body, 0, 4));
+        $this->assertSame('WEBP', substr($body, 8, 4));
     }
 
     /**
@@ -178,7 +180,7 @@ class ImagesControllerTest extends TestCase
         // fit=invalid and w=0 should yield no transform path.
         $this->get('/images/serve/1?fit=invalid&w=0&h=0&fm=bogus&q=nope');
         $this->assertResponseOk();
-        $this->assertSame('image/png', $this->_response->getHeaderLine('Content-Type'));
+        $this->assertSame('image/webp', $this->_response->getHeaderLine('Content-Type'));
     }
 
     /**


### PR DESCRIPTION
This pull request refactors how images are served and how missing or fallback images are handled, with a focus on standardizing the fallback image format to WebP and delegating all admin image serving to the public endpoint. It also updates related tests and improves image loading performance in the admin UI.

**Image serving and fallback changes:**

* The admin image serving endpoint (`/admin/images/serve/:id`) now always redirects to the public endpoint (`/images/serve/:id`), preserving all query parameters. This centralizes all image serving logic and fallback handling in the public controller.
* The fallback "transparent image" placeholder is now a 1x1 transparent WebP instead of PNG, and all code paths and tests are updated accordingly. This affects both missing records and missing files. [[1]](diffhunk://#diff-640368c08b70aa36779c1c5cae4c68b1d78a150bc4e44365ce02f05e861aebf1L70-R70) [[2]](diffhunk://#diff-640368c08b70aa36779c1c5cae4c68b1d78a150bc4e44365ce02f05e861aebf1L79-R79) [[3]](diffhunk://#diff-640368c08b70aa36779c1c5cae4c68b1d78a150bc4e44365ce02f05e861aebf1L111-R111) [[4]](diffhunk://#diff-640368c08b70aa36779c1c5cae4c68b1d78a150bc4e44365ce02f05e861aebf1L298-R298) [[5]](diffhunk://#diff-640368c08b70aa36779c1c5cae4c68b1d78a150bc4e44365ce02f05e861aebf1L320-R320) [[6]](diffhunk://#diff-640368c08b70aa36779c1c5cae4c68b1d78a150bc4e44365ce02f05e861aebf1L334-R334) [[7]](diffhunk://#diff-640368c08b70aa36779c1c5cae4c68b1d78a150bc4e44365ce02f05e861aebf1L473-R484) [[8]](diffhunk://#diff-6c340c98ba7955024dfb18076262d64db36949fc0aebbe15bd29c31f6e381087L797-L815)

**API and serialization improvements:**

* The image serialization now exposes both `url` (canonical public serving endpoint) and `admin_url` (legacy admin endpoint) fields for clarity and backward compatibility.

**Admin UI performance:**

* The image cropper in the admin UI now uses eager loading, synchronous decoding, and high fetch priority for the main image, improving perceived performance during editing.

**Test updates:**

* All tests are updated to expect the new WebP placeholder format and to verify that the admin endpoint redirects to the public endpoint, including checks for query parameter preservation and correct response headers. [[1]](diffhunk://#diff-824ee6309b33806567392c8e5424478c57d377b789dbf281c2436f4563cdb851L374-R386) [[2]](diffhunk://#diff-f79ebf182ed6bfef19098c81d41f3bf5085b8df2bb5cee3a10bd87d2ad7c22ccL223-R223) [[3]](diffhunk://#diff-f79ebf182ed6bfef19098c81d41f3bf5085b8df2bb5cee3a10bd87d2ad7c22ccL244-R277) [[4]](diffhunk://#diff-f79ebf182ed6bfef19098c81d41f3bf5085b8df2bb5cee3a10bd87d2ad7c22ccL283-R288) [[5]](diffhunk://#diff-f79ebf182ed6bfef19098c81d41f3bf5085b8df2bb5cee3a10bd87d2ad7c22ccL348-R353) [[6]](diffhunk://#diff-f79ebf182ed6bfef19098c81d41f3bf5085b8df2bb5cee3a10bd87d2ad7c22ccL433-R438) [[7]](diffhunk://#diff-a387eedd2c3180578171b271d12986968e01590c44ee28ed2d2dfc7ab0277172L61-R89) [[8]](diffhunk://#diff-a387eedd2c3180578171b271d12986968e01590c44ee28ed2d2dfc7ab0277172L181-R183)
