### PR TITLE
Add Content-Length header to served image responses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [dev]
   pull_request:
     branches: [dev, main]
   workflow_dispatch:

--- a/src/Controller/ImagesController.php
+++ b/src/Controller/ImagesController.php
@@ -111,10 +111,14 @@ class ImagesController extends AppController
             return $this->placeholderTransparentWebp();
         }
 
+        // Calculate the precise size of the image payload in bytes
+        $contentLength = mb_strlen($body, '8bit');
+
         return $this->getResponse()
             ->withType($mime)
             ->withHeader('ETag', $etag)
             ->withHeader('Cache-Control', $cacheControl)
+            ->withHeader('Content-Length', (string)$contentLength)
             ->withStringBody($body);
     }
 


### PR DESCRIPTION
This pull request introduces a minor update to the CI workflow configuration and enhances the image serving controller to include a more accurate response header.

Workflow configuration:

* The CI workflow now only runs on pull requests to the `dev` and `main` branches, removing the previous trigger for direct pushes to `dev`. This helps ensure that CI checks are consistently run for proposed changes before merging.

Image response improvement:

* The `ImagesController` now adds a `Content-Length` header based on the precise byte size of the image payload, improving HTTP response accuracy and client compatibility.
