### PR TITLE
Enhance image serving with retry logic for broken images

### DIFF
--- a/src/Controller/ImagesController.php
+++ b/src/Controller/ImagesController.php
@@ -65,61 +65,70 @@ class ImagesController extends AppController
     {
         $request = $this->getRequest();
         $request->allowMethod(['get', 'head']);
-        $image = $this->fetchTable('Images')->find()->where(['id' => $id])->first();
-        if (!$image) {
-            return $this->placeholderTransparentWebp();
-        }
-        $profileName = strtolower((string)$request->getQuery('profile'));
-        $profileConfig = $this->getProfileConfig($profileName);
 
-        $variant = $this->resolveVariantForProfile((string)$request->getQuery('variant'), $profileConfig);
-        [$path, $mime] = $this->resolvePath($image, $variant);
+        try {
+            $image = $this->fetchTable('Images')->find()->where(['id' => $id])->first();
+            if (!$image) {
+                return $this->placeholderTransparentWebp();
+            }
+            $profileName = strtolower((string)$request->getQuery('profile'));
+            $profileConfig = $this->getProfileConfig($profileName);
 
-        if (!is_file($path)) {
-            return $this->placeholderTransparentWebp();
-        }
+            $variant = $this->resolveVariantForProfile((string)$request->getQuery('variant'), $profileConfig);
+            [$path, $mime] = $this->resolvePath($image, $variant);
 
-        $cacheControl = 'public, max-age=3600, must-revalidate';
+            if (!is_file($path)) {
+                return $this->placeholderTransparentWebp();
+            }
 
-        $etagVariant = $variant;
-        if ($profileName !== '') {
-            $etagVariant .= '|profile:' . $profileName;
-        }
+            $cacheControl = 'public, max-age=3600, must-revalidate';
 
-        $etag = $this->buildEtag((string)($image->hash ?? ''), $etagVariant, []);
+            $etagVariant = $variant;
+            if ($profileName !== '') {
+                $etagVariant .= '|profile:' . $profileName;
+            }
 
-        $transform = $this->extractTransformParams($profileConfig);
-        if ($this->shouldAutoServeWebp($mime) && ($transform === null || !isset($transform['fm']))) {
-            $transform ??= [];
-            $transform['fm'] = 'webp';
-        }
+            $etag = $this->buildEtag((string)($image->hash ?? ''), $etagVariant, []);
 
-        if ($transform !== null) {
-            return $this->serveTransformed($image, $path, $mime, $etagVariant, $transform, $cacheControl);
-        }
+            $transform = $this->extractTransformParams($profileConfig);
+            if ($this->shouldAutoServeWebp($mime) && ($transform === null || !isset($transform['fm']))) {
+                $transform ??= [];
+                $transform['fm'] = 'webp';
+            }
 
-        $ifNoneMatch = $request->getHeaderLine('If-None-Match');
-        if ($ifNoneMatch !== '' && $ifNoneMatch === $etag) {
+            if ($transform !== null) {
+                return $this->serveTransformed($image, $path, $mime, $etagVariant, $transform, $cacheControl);
+            }
+
+            $ifNoneMatch = $request->getHeaderLine('If-None-Match');
+            if ($ifNoneMatch !== '' && $ifNoneMatch === $etag) {
+                return $this->getResponse()
+                    ->withStatus(304)
+                    ->withHeader('ETag', $etag)
+                    ->withHeader('Cache-Control', $cacheControl);
+            }
+
+            $body = file_get_contents($path) ?: '';
+            if ($body === '') {
+                return $this->placeholderTransparentWebp();
+            }
+
             return $this->getResponse()
-                ->withStatus(304)
+                ->withType($mime)
                 ->withHeader('ETag', $etag)
-                ->withHeader('Cache-Control', $cacheControl);
-        }
+                ->withHeader('Cache-Control', $cacheControl)
+                ->withStringBody($body);
+        } catch (Throwable $e) {
+            $query = json_encode($request->getQueryParams());
+            Log::error(sprintf(
+                'image_serve_failed id=%d query=%s error=%s',
+                $id,
+                $query === false ? '{}' : $query,
+                $e->getMessage(),
+            ));
 
-        $body = file_get_contents($path) ?: '';
-        if ($body === '') {
             return $this->placeholderTransparentWebp();
         }
-
-        // Calculate the precise size of the image payload in bytes
-        $contentLength = mb_strlen($body, '8bit');
-
-        return $this->getResponse()
-            ->withType($mime)
-            ->withHeader('ETag', $etag)
-            ->withHeader('Cache-Control', $cacheControl)
-            ->withHeader('Content-Length', (string)$contentLength)
-            ->withStringBody($body);
     }
 
     /**
@@ -332,6 +341,13 @@ class ImagesController extends AppController
                 ->withHeader('Cache-Control', $cacheControl)
                 ->withStringBody($body);
         } catch (Throwable $e) {
+            Log::warning(sprintf(
+                'image_transform_failed id=%s path=%s error=%s',
+                (string)($image->id ?? 'unknown'),
+                $path,
+                $e->getMessage(),
+            ));
+
             // Degrade gracefully to original bytes if transform fails.
             $body = file_get_contents($path) ?: '';
             if ($body === '') {

--- a/templates/layout/admin.php
+++ b/templates/layout/admin.php
@@ -60,6 +60,100 @@
     <?= $this->Html->script('admin.js') ?>
     <?= $this->Html->script('admin-image-pages.js') ?>
     <?= $this->fetch('script') ?>
+    <script>
+        (function () {
+            if (window.__rhImageRetryInit) {
+                return;
+            }
+            window.__rhImageRetryInit = true;
+
+            function isServeUrl(url) {
+                if (!url) {
+                    return false;
+                }
+                try {
+                    const parsed = new URL(url, window.location.origin);
+                    return parsed.pathname.indexOf('/images/serve/') === 0;
+                } catch (err) {
+                    return false;
+                }
+            }
+
+            function bustUrl(url) {
+                const parsed = new URL(url, window.location.origin);
+                parsed.searchParams.set('_ts', String(Date.now()));
+
+                return parsed.pathname + parsed.search;
+            }
+
+            function bustSrcset(srcset) {
+                return srcset
+                    .split(',')
+                    .map(function (candidate) {
+                        const trimmed = candidate.trim();
+                        if (!trimmed) {
+                            return trimmed;
+                        }
+
+                        const splitAt = trimmed.search(/\s/);
+                        const url = splitAt === -1 ? trimmed : trimmed.slice(0, splitAt);
+                        const descriptor = splitAt === -1 ? '' : trimmed.slice(splitAt);
+
+                        if (!isServeUrl(url)) {
+                            return trimmed;
+                        }
+
+                        return bustUrl(url) + descriptor;
+                    })
+                    .join(', ');
+            }
+
+            function retryBrokenImage(img) {
+                if (!(img instanceof HTMLImageElement)) {
+                    return;
+                }
+                if (img.dataset.rhRetryAttempted === '1') {
+                    return;
+                }
+
+                const current = img.currentSrc || img.getAttribute('src') || '';
+                if (!isServeUrl(current)) {
+                    return;
+                }
+
+                img.dataset.rhRetryAttempted = '1';
+
+                const picture = img.closest('picture');
+                if (picture) {
+                    picture.querySelectorAll('source').forEach(function (sourceEl) {
+                        const srcset = sourceEl.getAttribute('srcset');
+                        if (!srcset) {
+                            return;
+                        }
+                        sourceEl.setAttribute('srcset', bustSrcset(srcset));
+                    });
+                }
+
+                const baseSrc = img.getAttribute('src') || current;
+                img.setAttribute('src', bustUrl(baseSrc));
+            }
+
+            function retryAlreadyBroken() {
+                document.querySelectorAll('img').forEach(function (img) {
+                    if (img.complete && img.naturalWidth === 0) {
+                        retryBrokenImage(img);
+                    }
+                });
+            }
+
+            document.addEventListener('error', function (event) {
+                retryBrokenImage(event.target);
+            }, true);
+
+            document.addEventListener('DOMContentLoaded', retryAlreadyBroken);
+            document.addEventListener('turbo:load', retryAlreadyBroken);
+        })();
+    </script>
 </head>
 
 <body>

--- a/templates/layout/default.php
+++ b/templates/layout/default.php
@@ -135,6 +135,100 @@
         document.addEventListener('DOMContentLoaded', initNavBehavior);
         document.addEventListener('turbo:load', initNavBehavior);
     </script>
+    <script>
+        (function () {
+            if (window.__rhImageRetryInit) {
+                return;
+            }
+            window.__rhImageRetryInit = true;
+
+            function isServeUrl(url) {
+                if (!url) {
+                    return false;
+                }
+                try {
+                    const parsed = new URL(url, window.location.origin);
+                    return parsed.pathname.indexOf('/images/serve/') === 0;
+                } catch (err) {
+                    return false;
+                }
+            }
+
+            function bustUrl(url) {
+                const parsed = new URL(url, window.location.origin);
+                parsed.searchParams.set('_ts', String(Date.now()));
+
+                return parsed.pathname + parsed.search;
+            }
+
+            function bustSrcset(srcset) {
+                return srcset
+                    .split(',')
+                    .map(function (candidate) {
+                        const trimmed = candidate.trim();
+                        if (!trimmed) {
+                            return trimmed;
+                        }
+
+                        const splitAt = trimmed.search(/\s/);
+                        const url = splitAt === -1 ? trimmed : trimmed.slice(0, splitAt);
+                        const descriptor = splitAt === -1 ? '' : trimmed.slice(splitAt);
+
+                        if (!isServeUrl(url)) {
+                            return trimmed;
+                        }
+
+                        return bustUrl(url) + descriptor;
+                    })
+                    .join(', ');
+            }
+
+            function retryBrokenImage(img) {
+                if (!(img instanceof HTMLImageElement)) {
+                    return;
+                }
+                if (img.dataset.rhRetryAttempted === '1') {
+                    return;
+                }
+
+                const current = img.currentSrc || img.getAttribute('src') || '';
+                if (!isServeUrl(current)) {
+                    return;
+                }
+
+                img.dataset.rhRetryAttempted = '1';
+
+                const picture = img.closest('picture');
+                if (picture) {
+                    picture.querySelectorAll('source').forEach(function (sourceEl) {
+                        const srcset = sourceEl.getAttribute('srcset');
+                        if (!srcset) {
+                            return;
+                        }
+                        sourceEl.setAttribute('srcset', bustSrcset(srcset));
+                    });
+                }
+
+                const baseSrc = img.getAttribute('src') || current;
+                img.setAttribute('src', bustUrl(baseSrc));
+            }
+
+            function retryAlreadyBroken() {
+                document.querySelectorAll('img').forEach(function (img) {
+                    if (img.complete && img.naturalWidth === 0) {
+                        retryBrokenImage(img);
+                    }
+                });
+            }
+
+            document.addEventListener('error', function (event) {
+                retryBrokenImage(event.target);
+            }, true);
+
+            document.addEventListener('DOMContentLoaded', retryAlreadyBroken);
+            document.addEventListener('turbo:load', retryAlreadyBroken);
+        })();
+    </script>
 </head>
 
 <?php


### PR DESCRIPTION
This pull request improves the reliability and robustness of image handling across the application, both on the backend and frontend. On the backend, it adds better error handling and logging for image serving and transformation failures, ensuring graceful degradation when issues occur. On the frontend, it introduces a script to automatically retry loading broken images by cache-busting their URLs, enhancing the user experience when transient errors happen.

**Backend: Improved error handling and logging for image serving**

* Wrapped the main logic of the `serve` method in `ImagesController` with a `try-catch` block to catch all exceptions, log detailed error information, and gracefully degrade by serving a placeholder image if any error occurs. [[1]](diffhunk://#diff-640368c08b70aa36779c1c5cae4c68b1d78a150bc4e44365ce02f05e861aebf1R68-R69) [[2]](diffhunk://#diff-640368c08b70aa36779c1c5cae4c68b1d78a150bc4e44365ce02f05e861aebf1L114-R131)
* Enhanced error logging in the `serveTransformed` method to include image ID, file path, and error message, aiding in debugging transformation failures.

**Frontend: Automatic retry for broken images**

* Added a script to both `admin.php` and `default.php` layouts that detects broken images served from `/images/serve/`, and retries loading them once by cache-busting their URLs (adding a timestamp query parameter). This works for both `src` and `srcset` attributes, and is triggered on image load errors and on page load for already broken images. [[1]](diffhunk://#diff-977d47f25d2787951d0686e79cbdf8a202546ee6bd105865c3c91f622658952aR63-R156) [[2]](diffhunk://#diff-19efa77022d02e72d1c598ef2f2687da466c7459920c6a9460bfe4cc6c03ee6fR138-R231)