### PR TITLE
Implement DataTables integration for admin images index

### DIFF
--- a/src/Controller/Admin/ImagesController.php
+++ b/src/Controller/Admin/ImagesController.php
@@ -132,9 +132,56 @@ class ImagesController extends AppController
     public function index(): void
     {
         $this->getRequest()->allowMethod(['get']);
-        $images = $this->imagesAdminService->getIndexImages();
-        $this->set(compact('images'));
+        $this->set('imageCount', $this->imagesAdminService->getTotalCount());
         // Let Cake render the template normally (no explicit return of Response which caused blank output)
+    }
+
+    /**
+     * DataTables server-side JSON endpoint for admin images index.
+     */
+    public function datatables(): Response
+    {
+        $request = $this->getRequest();
+        $request->allowMethod(['get']);
+
+        $orderDir = 'desc';
+        $orderColumn = 'id';
+
+        $order = $request->getQuery('order');
+        $columns = $request->getQuery('columns');
+        if (is_array($order) && !empty($order)) {
+            $firstOrder = reset($order);
+            if (is_array($firstOrder)) {
+                $dir = strtolower((string)($firstOrder['dir'] ?? 'desc'));
+                if (in_array($dir, ['asc', 'desc'], true)) {
+                    $orderDir = $dir;
+                }
+
+                $columnIndex = (int)($firstOrder['column'] ?? 0);
+                if (is_array($columns) && isset($columns[$columnIndex]['data'])) {
+                    $candidate = $columns[$columnIndex]['data'];
+                    if (is_string($candidate) && $candidate !== '') {
+                        $orderColumn = $candidate;
+                    }
+                }
+            }
+        }
+
+        $result = $this->imagesAdminService->buildIndexDataTablesResponse([
+            'draw' => (int)$request->getQuery('draw'),
+            'start' => (int)$request->getQuery('start'),
+            'length' => (int)$request->getQuery('length'),
+            'searchValue' => trim((string)($request->getQuery('search')['value'] ?? '')),
+            'orderDir' => $orderDir,
+            'orderColumn' => $orderColumn,
+        ]);
+
+        return $this->json([
+            'draw' => $result['draw'],
+            'recordsTotal' => $result['total'],
+            'recordsFiltered' => $result['filtered'],
+            'data' => $result['data'],
+        ]);
     }
 
     /**

--- a/src/Controller/ImagesController.php
+++ b/src/Controller/ImagesController.php
@@ -75,6 +75,23 @@ class ImagesController extends AppController
             $profileConfig = $this->getProfileConfig($profileName);
 
             $variant = $this->resolveVariantForProfile((string)$request->getQuery('variant'), $profileConfig);
+
+            // Strict variant enforcement: if a named stored variant was requested but the image
+            // record has no entry for it, return a placeholder immediately rather than falling
+            // back to a full-resolution on-the-fly transform.  Loading the admin images index
+            // with many images that lack a stored thumb variant would otherwise trigger
+            // simultaneous full-res Intervention/Image transforms, exhausting PHP-FPM workers
+            // and causing Cloudflare to receive empty responses (→ 520).
+            if ($variant !== '') {
+                $rawVariants = $image->variants;
+                if (is_string($rawVariants)) {
+                    $rawVariants = json_decode($rawVariants, true);
+                }
+                if (!is_array($rawVariants) || !isset($rawVariants[$variant]['file'])) {
+                    return $this->placeholderTransparentWebp();
+                }
+            }
+
             [$path, $mime] = $this->resolvePath($image, $variant);
 
             if (!is_file($path)) {

--- a/src/Service/ImagesAdminService.php
+++ b/src/Service/ImagesAdminService.php
@@ -5,7 +5,7 @@ namespace App\Service;
 
 use App\Model\Entity\Image;
 use App\Model\Table\ImagesTable;
-use Cake\Datasource\ResultSetInterface;
+use Cake\I18n\Number;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -57,13 +57,136 @@ class ImagesAdminService
     }
 
     /**
-     * Load index data for the images management page.
-     *
-     * @return \Cake\Datasource\ResultSetInterface
+     * Total images count for index heading text.
      */
-    public function getIndexImages(): ResultSetInterface
+    public function getTotalCount(): int
     {
-        return $this->imagesTable->find()->orderByDesc('id')->limit(100)->all();
+        return (int)$this->imagesTable->find()->count();
+    }
+
+    /**
+     * Build DataTables server-side payload for admin images index.
+     *
+     * @param array<string,mixed> $params
+     * @return array{draw:int,total:int,filtered:int,data:array<int,array<string,mixed>>}
+     */
+    public function buildIndexDataTablesResponse(array $params): array
+    {
+        $draw = max(0, (int)($params['draw'] ?? 0));
+        $start = max(0, (int)($params['start'] ?? 0));
+        $length = (int)($params['length'] ?? 15);
+        if ($length <= 0) {
+            $length = 15;
+        }
+        $length = min($length, 120);
+
+        $searchValue = trim((string)($params['searchValue'] ?? ''));
+        $orderDir = strtolower((string)($params['orderDir'] ?? 'desc')) === 'asc' ? 'asc' : 'desc';
+        $orderColumn = (string)($params['orderColumn'] ?? 'id');
+        $sortField = $this->resolveIndexSortField($orderColumn);
+
+        $total = (int)$this->imagesTable->find()->count();
+
+        $query = $this->imagesTable->find();
+        if ($searchValue !== '') {
+            $conditions = [
+                'Images.original_name LIKE' => '%' . $searchValue . '%',
+                'Images.filename LIKE' => '%' . $searchValue . '%',
+                'Images.mime LIKE' => '%' . $searchValue . '%',
+                'Images.status LIKE' => '%' . $searchValue . '%',
+            ];
+            if (ctype_digit($searchValue)) {
+                $conditions[] = ['Images.id' => (int)$searchValue];
+            }
+            $query->where(['OR' => $conditions]);
+        }
+
+        $filtered = (int)$query->count();
+
+        $rows = $query
+            ->order([$sortField => $orderDir])
+            ->offset($start)
+            ->limit($length)
+            ->all();
+
+        $data = [];
+        foreach ($rows as $row) {
+            $rowData = is_array($row) ? $row : $row->toArray();
+
+            $id = (int)($rowData['id'] ?? 0);
+            $originalName = (string)($rowData['original_name'] ?? '');
+            $filename = (string)($rowData['filename'] ?? '');
+            $name = $originalName !== '' ? $originalName : $filename;
+            $mime = (string)($rowData['mime'] ?? '');
+            $byteSize = (int)($rowData['byte_size'] ?? 0);
+            $width = (int)($rowData['width'] ?? 0);
+            $height = (int)($rowData['height'] ?? 0);
+            $dimensions = $width > 0 && $height > 0 ? ($width . 'x' . $height) : '-';
+
+            $status = (string)($rowData['status'] ?? 'unknown');
+            $statusClass = strtolower($status) === 'active' ? 'bg-success' : 'bg-secondary';
+
+            $thumbUrl = '/images/serve/' . $id . '?variant=thumb';
+            $editUrl = '/admin/images/edit/' . $id;
+
+            $data[] = [
+                'id' => $id,
+                'preview' => sprintf(
+                    '<img src="%s" alt="" class="img-thumbnail" style="max-width:60px; height:auto;" ' .
+                    'loading="lazy" decoding="async">',
+                    $this->escapeHtml($thumbUrl),
+                ),
+                'original_name' => $this->escapeHtml($name),
+                'mime' => '<code>' . $this->escapeHtml($mime) . '</code>',
+                'size' => $this->escapeHtml((string)Number::toReadableSize($byteSize)),
+                'dimensions' => $this->escapeHtml($dimensions),
+                'status' => sprintf(
+                    '<span class="badge %s">%s</span>',
+                    $statusClass,
+                    $this->escapeHtml($status),
+                ),
+                'actions' => sprintf(
+                    '<a href="%s" class="btn btn-sm btn-primary">Edit</a>',
+                    $this->escapeHtml($editUrl),
+                ),
+            ];
+        }
+
+        return [
+            'draw' => $draw,
+            'total' => $total,
+            'filtered' => $filtered,
+            'data' => $data,
+        ];
+    }
+
+    /**
+     * Resolve DataTables column key to a sortable database field.
+     *
+     * @param string $column
+     * @return string
+     */
+    private function resolveIndexSortField(string $column): string
+    {
+        return match ($column) {
+            'original_name' => 'Images.original_name',
+            'mime' => 'Images.mime',
+            'size' => 'Images.byte_size',
+            'dimensions' => 'Images.width',
+            'status' => 'Images.status',
+            default => 'Images.id',
+        };
+    }
+
+    /**
+     * Escape helper for HTML fragments returned to DataTables.
+     *
+     * @param string $value
+     * @return string
+     */
+    private function escapeHtml(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
     }
 
     /**

--- a/templates/Admin/Images/index.php
+++ b/templates/Admin/Images/index.php
@@ -1,56 +1,159 @@
 <?php
 /**
  * @var \App\View\AppView $this
- * @var mixed $images
+ * @var int $imageCount
  */
 $this->assign('title', 'Images');
+$datatableUrl = $this->Url->build(['prefix' => 'Admin', 'controller' => 'Images', 'action' => 'datatables']);
 ?>
-<div class="container py-4">
-  <h1 class="mb-4">Images</h1>
-  <table class="table table-sm align-middle table-striped">
-    <thead>
-      <tr>
-        <th>ID</th>
-        <th>Preview</th>
-        <th>Original Name</th>
-        <th>Mime</th>
-        <th>Size</th>
-        <th>Dimensions</th>
-        <th>Status</th>
-        <th>Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-    <?php foreach ($images as $img) : ?>
-      <tr>
-        <td><?= h($img->id) ?></td>
-        <td>
-          <?php
-          // Use stored thumb variant so custom crops are shown
-            $thumbParams = [
-                'variant' => 'thumb',
-            ];
-            ?>
-          <?= $this->ImageServe->picture(
-              $img,
-              $thumbParams,
-              [
-                  'alt' => '',
-                  'class' => 'img-thumbnail',
-                  'style' => 'max-width:60px; height:auto;',
-              ],
-          ) ?>
-        </td>
-        <td><?= h($img->original_name ?: $img->filename) ?></td>
-        <td><code><?= h($img->mime) ?></code></td>
-        <td><?= $this->Number->toReadableSize($img->byte_size) ?></td>
-        <td><?= h($img->width . '×' . $img->height) ?></td>
-        <td><span class="badge bg-secondary"><?= h($img->status) ?></span></td>
-        <td>
-          <?= $this->Html->link('Edit', ['action' => 'edit',$img->id], ['class' => 'btn btn-sm btn-primary']) ?>
-        </td>
-      </tr>
-    <?php endforeach; ?>
-    </tbody>
-  </table>
+<?php $this->start('css'); ?>
+<link rel="stylesheet" href="https://cdn.datatables.net/1.13.7/css/dataTables.bootstrap5.min.css">
+<link rel="stylesheet" href="https://cdn.datatables.net/scroller/2.3.0/css/scroller.bootstrap5.min.css">
+<?php $this->end(); ?>
+
+<div class="container-fluid py-4">
+    <div class="row mb-3">
+        <div class="col">
+            <h1 class="mb-1">Images</h1>
+            <p class="text-muted mb-3">
+                All Images: <?= (int)$imageCount ?> total.
+            </p>
+            <a href="<?= $this->Url->build(['action' => 'bulkUploadForm']) ?>" class="btn btn-success mb-3">
+                <i class="bi bi-upload"></i> Upload Images
+            </a>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col">
+            <div class="d-flex align-items-center gap-2 mb-2">
+                <label for="images-search" class="form-label mb-0 text-nowrap">Search:</label>
+                <input type="search" id="images-search" class="form-control form-control-sm" placeholder="Name, mime, status, id..." autocomplete="off">
+            </div>
+
+            <table
+                id="images-table"
+                class="table table-striped table-bordered table-hover align-middle w-100"
+                data-datatables-url="<?= h($datatableUrl) ?>"
+            >
+                <thead class="table-dark">
+                    <tr>
+                        <th>ID</th>
+                        <th style="width: 5rem;">Preview</th>
+                        <th>Original Name</th>
+                        <th>Mime</th>
+                        <th>Size</th>
+                        <th>Dimensions</th>
+                        <th>Status</th>
+                        <th style="width: 8rem;">Actions</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </div>
+    </div>
 </div>
+
+<?php $this->start('script'); ?>
+<script src="https://cdn.datatables.net/1.13.7/js/jquery.dataTables.min.js"></script>
+<script src="https://cdn.datatables.net/1.13.7/js/dataTables.bootstrap5.min.js"></script>
+<script src="https://cdn.datatables.net/scroller/2.3.0/js/dataTables.scroller.min.js"></script>
+<script>
+(function () {
+    'use strict';
+
+    var dtInstance = null;
+    var searchDebounce = null;
+
+    function destroyTable() {
+        if (dtInstance) {
+            try {
+                dtInstance.destroy(false);
+            } catch (_) {
+                // no-op
+            }
+            dtInstance = null;
+        }
+    }
+
+    function initImagesTable() {
+        var tableEl = document.getElementById('images-table');
+        if (!tableEl || !window.jQuery || typeof $.fn.DataTable !== 'function') {
+            return;
+        }
+
+        if ($.fn.DataTable.isDataTable('#images-table')) {
+            destroyTable();
+        }
+
+        var dataUrl = tableEl.dataset.datatablesUrl;
+
+        dtInstance = $('#images-table').DataTable({
+            serverSide: true,
+            processing: true,
+            ajax: {
+                url: dataUrl,
+                type: 'GET'
+            },
+            columns: [
+                { data: 'id', name: 'id' },
+                { data: 'preview', name: 'preview', orderable: false, searchable: false },
+                { data: 'original_name', name: 'original_name' },
+                { data: 'mime', name: 'mime' },
+                { data: 'size', name: 'size' },
+                { data: 'dimensions', name: 'dimensions' },
+                { data: 'status', name: 'status' },
+                { data: 'actions', name: 'actions', orderable: false, searchable: false }
+            ],
+            order: [[0, 'desc']],
+            pageLength: 15,
+            lengthMenu: [15, 30, 60, 120],
+            paging: true,
+            pagingType: 'simple_numbers',
+            scrollY: '60vh',
+            scrollX: true,
+            scrollCollapse: true,
+            scroller: true,
+            deferRender: true,
+            language: {
+                processing: '<span class="spinner-border spinner-border-sm me-2" role="status"></span>Loading...',
+                search: '',
+                zeroRecords: 'No matching images found.',
+                info: 'Showing _START_ to _END_ of _TOTAL_ images',
+                infoEmpty: 'No images found.',
+                infoFiltered: '(filtered from _MAX_ total images)'
+            },
+            dom: 'rltip'
+        });
+
+        var searchInput = document.getElementById('images-search');
+        if (searchInput) {
+            searchInput.addEventListener('input', function () {
+                clearTimeout(searchDebounce);
+                searchDebounce = setTimeout(function () {
+                    if (dtInstance) {
+                        dtInstance.search(searchInput.value).draw();
+                    }
+                }, 250);
+            });
+        }
+    }
+
+    var adminFrame = document.getElementById('admin-content');
+    if (adminFrame && !adminFrame._imagesFrameListenerAttached) {
+        adminFrame._imagesFrameListenerAttached = true;
+        adminFrame.addEventListener('turbo:before-frame-render', destroyTable);
+    }
+    document.addEventListener('turbo:before-cache', destroyTable);
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initImagesTable);
+    } else {
+        initImagesTable();
+    }
+
+    document.addEventListener('turbo:load', initImagesTable);
+    document.addEventListener('turbo:frame-load', initImagesTable);
+}());
+</script>
+<?php $this->end(); ?>

--- a/templates/layout/admin.php
+++ b/templates/layout/admin.php
@@ -66,6 +66,7 @@
                 return;
             }
             window.__rhImageRetryInit = true;
+            let retrySequence = 0;
 
             function isServeUrl(url) {
                 if (!url) {
@@ -123,19 +124,24 @@
 
                 img.dataset.rhRetryAttempted = '1';
 
-                const picture = img.closest('picture');
-                if (picture) {
-                    picture.querySelectorAll('source').forEach(function (sourceEl) {
-                        const srcset = sourceEl.getAttribute('srcset');
-                        if (!srcset) {
-                            return;
-                        }
-                        sourceEl.setAttribute('srcset', bustSrcset(srcset));
-                    });
-                }
+                // Stagger retries to avoid amplifying transient backend overload.
+                const delayMs = Math.min(2000, retrySequence * 75);
+                retrySequence += 1;
+                window.setTimeout(function () {
+                    const picture = img.closest('picture');
+                    if (picture) {
+                        picture.querySelectorAll('source').forEach(function (sourceEl) {
+                            const srcset = sourceEl.getAttribute('srcset');
+                            if (!srcset) {
+                                return;
+                            }
+                            sourceEl.setAttribute('srcset', bustSrcset(srcset));
+                        });
+                    }
 
-                const baseSrc = img.getAttribute('src') || current;
-                img.setAttribute('src', bustUrl(baseSrc));
+                    const baseSrc = img.getAttribute('src') || current;
+                    img.setAttribute('src', bustUrl(baseSrc));
+                }, delayMs);
             }
 
             function retryAlreadyBroken() {
@@ -152,6 +158,7 @@
 
             document.addEventListener('DOMContentLoaded', retryAlreadyBroken);
             document.addEventListener('turbo:load', retryAlreadyBroken);
+            document.addEventListener('turbo:frame-load', retryAlreadyBroken);
         })();
     </script>
 </head>

--- a/tests/TestCase/Controller/Admin/ImagesControllerTest.php
+++ b/tests/TestCase/Controller/Admin/ImagesControllerTest.php
@@ -452,6 +452,33 @@ class ImagesControllerTest extends TestCase
     }
 
     /**
+     * Tests datatables endpoint returns expected JSON shape.
+     */
+    public function testDatatablesReturnsExpectedJsonShape(): void
+    {
+        $this->mockIdentity();
+        $this->get('/admin/images/datatables?draw=1&start=0&length=15');
+        $this->assertResponseCode(200);
+        $this->assertSame('application/json', $this->_response->getHeaderLine('Content-Type'));
+
+        $json = json_decode((string)$this->_response->getBody(), true);
+        $this->assertIsArray($json);
+        $this->assertSame(1, $json['draw'] ?? null);
+        $this->assertArrayHasKey('recordsTotal', $json);
+        $this->assertArrayHasKey('recordsFiltered', $json);
+        $this->assertArrayHasKey('data', $json);
+        $this->assertIsArray($json['data']);
+        $this->assertLessThanOrEqual(15, count($json['data']));
+
+        if (!empty($json['data'])) {
+            $row = $json['data'][0];
+            $this->assertArrayHasKey('id', $row);
+            $this->assertArrayHasKey('preview', $row);
+            $this->assertArrayHasKey('actions', $row);
+        }
+    }
+
+    /**
      * Tests admin edit renders form.
      */
     public function testAdminEditRendersForm(): void


### PR DESCRIPTION
This pull request implements a major refactor of the admin images index to use DataTables for server-side processing, improving performance and scalability when browsing large image sets. It introduces a new JSON endpoint for DataTables, updates the UI to support dynamic loading and searching, and adds stricter backend enforcement for image variant serving to prevent backend overload. The changes also enhance robustness and test coverage.

**Admin Images Index Refactor and DataTables Integration:**

* Adds a new `datatables` action to `ImagesController` and a corresponding `buildIndexDataTablesResponse` method in `ImagesAdminService` to provide server-side JSON responses for DataTables, supporting pagination, search, and sorting. (`src/Controller/Admin/ImagesController.php` [[1]](diffhunk://#diff-6c340c98ba7955024dfb18076262d64db36949fc0aebbe15bd29c31f6e381087L135-R186) `src/Service/ImagesAdminService.php` [[2]](diffhunk://#diff-a423f8a7925939649f1d28648a79adc518d790f4a72f9c0c02a9b9f889050d81L60-R189)
* Updates the admin images index template to use DataTables with AJAX loading, search, and improved UI, replacing the previous static table rendering. (`templates/Admin/Images/index.php` [templates/Admin/Images/index.phpL4-R159](diffhunk://#diff-34c19f786f23b1ed4e4f12751f2668ca26b6a75e67bca7d18066b2c115370d5eL4-R159))
* Adds a test to verify the new DataTables endpoint returns the expected JSON structure. (`tests/TestCase/Controller/Admin/ImagesControllerTest.php` [tests/TestCase/Controller/Admin/ImagesControllerTest.phpR454-R480](diffhunk://#diff-f79ebf182ed6bfef19098c81d41f3bf5085b8df2bb5cee3a10bd87d2ad7c22ccR454-R480))

**Image Serving Robustness:**

* Enforces strict variant checks in the public `serve` endpoint: if a requested stored variant is missing, a placeholder is returned instead of triggering an on-the-fly transform, preventing backend overload when many images lack thumbnails. (`src/Controller/ImagesController.php` [src/Controller/ImagesController.phpR78-R94](diffhunk://#diff-640368c08b70aa36779c1c5cae4c68b1d78a150bc4e44365ce02f05e861aebf1R78-R94))

**Frontend Robustness Improvements:**

* Improves the broken image retry logic in the admin layout by staggering retries to avoid amplifying backend overload and ensuring retries are triggered on more navigation events. (`templates/layout/admin.php` [[1]](diffhunk://#diff-977d47f25d2787951d0686e79cbdf8a202546ee6bd105865c3c91f622658952aR69) [[2]](diffhunk://#diff-977d47f25d2787951d0686e79cbdf8a202546ee6bd105865c3c91f622658952aR127-R130) [[3]](diffhunk://#diff-977d47f25d2787951d0686e79cbdf8a202546ee6bd105865c3c91f622658952aR144) [[4]](diffhunk://#diff-977d47f25d2787951d0686e79cbdf8a202546ee6bd105865c3c91f622658952aR161)