### PR TITLE
Enhance image rendering with improved retry logic and connection checks

### DIFF
--- a/src/Service/ImagesAdminService.php
+++ b/src/Service/ImagesAdminService.php
@@ -134,6 +134,7 @@ class ImagesAdminService
                 'id' => $id,
                 'preview' => sprintf(
                     '<img src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" data-thumb-src="%s" alt="" ' .
+                    'data-rh-no-retry="1" ' .
                     'class="img-thumbnail js-admin-image-thumb" width="60" height="60" ' .
                     'style="width:60px; height:60px; object-fit:cover;" ' .
                     'loading="lazy" decoding="async">',

--- a/templates/Admin/Images/index.php
+++ b/templates/Admin/Images/index.php
@@ -69,19 +69,8 @@ $datatableUrl = $this->Url->build(['prefix' => 'Admin', 'controller' => 'Images'
     var thumbInFlight = 0;
     var initRetryTimer = null;
     var initRetryCount = 0;
-    var THUMB_MAX_CONCURRENT = 2;
-    var THUMB_OBSERVER_MARGIN = '200px 0px';
-
-    function bustUrl(url) {
-        try {
-            var parsed = new URL(url, window.location.origin);
-            parsed.searchParams.set('_ts', String(Date.now()));
-
-            return parsed.pathname + parsed.search;
-        } catch (_) {
-            return url;
-        }
-    }
+    var THUMB_MAX_CONCURRENT = 1;
+    var THUMB_OBSERVER_MARGIN = '50px 0px';
 
     function resetThumbLoader() {
         if (thumbObserver) {
@@ -120,19 +109,40 @@ $datatableUrl = $this->Url->build(['prefix' => 'Admin', 'controller' => 'Images'
                 img.addEventListener('load', function () {
                     img.dataset.thumbLoaded = '1';
                     img.removeAttribute('data-thumb-src');
+                    img.removeAttribute('data-thumb-queued');
                     done();
                 }, { once: true });
 
                 img.addEventListener('error', function () {
+                    img.removeAttribute('data-thumb-queued');
+
+                    if (!img.isConnected) {
+                        done();
+
+                        return;
+                    }
+
+                    // Retry once without cache-busting so caches can still be effective.
                     if (img.dataset.thumbRetried !== '1') {
                         img.dataset.thumbRetried = '1';
-                        img.src = bustUrl(thumbUrl);
+                        window.setTimeout(function () {
+                            if (!img.isConnected || img.dataset.thumbLoaded === '1') {
+                                return;
+                            }
+                            enqueueThumb(img);
+                            flushThumbQueue();
+                        }, 800);
                     }
                     done();
                 }, { once: true });
 
                 // Small stagger to avoid immediate N-way spikes when many rows appear at once.
                 window.setTimeout(function () {
+                    if (!img.isConnected || img.dataset.thumbLoaded === '1') {
+                        done();
+
+                        return;
+                    }
                     img.src = thumbUrl;
                 }, 90);
             }());
@@ -277,9 +287,9 @@ $datatableUrl = $this->Url->build(['prefix' => 'Admin', 'controller' => 'Images'
                 scrollCollapse: true,
                 scroller: {
                     loadingIndicator: true,
-                    displayBuffer: 2,
+                    displayBuffer: 1,
                     boundaryScale: 0.2,
-                    serverWait: 350,
+                    serverWait: 500,
                 },
                 deferRender: true,
                 language: {

--- a/templates/layout/admin.php
+++ b/templates/layout/admin.php
@@ -113,6 +113,12 @@
                 if (!(img instanceof HTMLImageElement)) {
                     return;
                 }
+                if (!img.isConnected) {
+                    return;
+                }
+                if (img.dataset.rhNoRetry === '1') {
+                    return;
+                }
                 if (img.dataset.rhRetryAttempted === '1') {
                     return;
                 }


### PR DESCRIPTION
This pull request focuses on improving the reliability and efficiency of image thumbnail loading in the admin interface, especially under error conditions and heavy scrolling. The most important changes are grouped below:

**Image thumbnail loading logic improvements:**

* Changed thumbnail loader to allow only one concurrent image load at a time (`THUMB_MAX_CONCURRENT = 1`) and reduced the observer margin to `50px 0px` to better control resource usage and avoid spikes when many images enter view.
* Improved error handling for thumbnail loading: when a thumbnail fails to load, it is now retried once after a short delay (800ms) rather than immediately with cache-busting, allowing caches to remain effective. Also, thumbnails are no longer retried if the image element is disconnected or already loaded.
* Added logic to remove the `data-thumb-queued` attribute on both successful and failed loads, ensuring proper state cleanup.

**Image retry behavior enhancements:**

* Updated the `retryBrokenImage` function to skip retrying images that are disconnected from the DOM or explicitly marked as non-retryable via the `data-rh-no-retry="1"` attribute.
* Added the `data-rh-no-retry="1"` attribute to thumbnail image markup to prevent automatic retries for certain images.

**Data table scrolling and performance tuning:**

* Adjusted the DataTables scroller configuration to reduce the display buffer from 2 to 1 and increased the server wait time from 350ms to 500ms, optimizing performance for large image sets.
