### PR TITLE
Add comprehensive tests for roster editing and multi-add features

### DIFF
--- a/js/tests/admin_bulk_table_controller.test.js
+++ b/js/tests/admin_bulk_table_controller.test.js
@@ -159,3 +159,420 @@ describe("admin-bulk-table controller", () => {
         expect(dataTableApi.destroy).not.toHaveBeenCalled();
     });
 });
+
+describe("admin-bulk-table controller branch coverage", () => {
+    let application;
+    let dataTableApi;
+    let dataTableFactory;
+    let jQueryMock;
+    let pagination;
+    let capturedOptions;
+
+    const startController = ({
+        includeTable = true,
+        includeBulkForm = true,
+        includeSelectAll = true,
+        includeActionSelect = true,
+        includeActionButton = true,
+        includeRows = true,
+        includeNameColumnValue = true,
+        includeOrderColumnValue = true,
+        includeOrderDirectionValue = true,
+    } = {}) => {
+        const rowMarkup = includeRows
+            ? `
+                <tr>
+                    <td><input type="checkbox" name="season_ids[]" value="10" data-admin-bulk-table-role="row-checkbox" /></td>
+                    <td>2023</td>
+                    <td>2024</td>
+                    <td>2023-2024</td>
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="season_ids[]" value="11" data-admin-bulk-table-role="row-checkbox" /></td>
+                    <td>2022</td>
+                    <td>2023</td>
+                    <td>2022-2023</td>
+                </tr>
+              `
+            : "";
+
+        document.body.innerHTML = `
+            <div
+                data-controller="admin-bulk-table"
+                data-admin-bulk-table-bulk-delete-url-value="/admin/seasons/bulk"
+                data-admin-bulk-table-item-type-value="seasons (bulk)"
+                data-admin-bulk-table-ids-name-value="season_ids[]"
+                data-admin-bulk-table-form-id-value="delete-form-seasons-bulk"
+                ${includeNameColumnValue ? 'data-admin-bulk-table-name-column-value="4"' : ""}
+                ${includeOrderColumnValue ? 'data-admin-bulk-table-order-column-value="1"' : ""}
+                ${includeOrderDirectionValue ? 'data-admin-bulk-table-order-direction-value="desc"' : ""}
+            >
+                ${
+                    includeBulkForm
+                        ? `<form id="bulk-action-form" data-admin-bulk-table-target="bulkForm">
+                        ${
+                            includeActionSelect
+                                ? `<select id="bulk-action-select" data-admin-bulk-table-target="actionSelect">
+                                <option value="">Choose...</option>
+                                <option value="delete">Delete</option>
+                                <option value="archive">Archive</option>
+                            </select>`
+                                : ""
+                        }
+                        ${
+                            includeActionButton
+                                ? '<button id="bulk-action-btn" data-admin-bulk-table-target="actionButton" type="submit" disabled>Go</button>'
+                                : ""
+                        }
+                    </form>`
+                        : ""
+                }
+
+                ${
+                    includeTable
+                        ? `<table id="seasons-table" data-admin-bulk-table-target="table">
+                        <tbody>
+                            ${
+                                includeSelectAll
+                                    ? '<tr><td><input type="checkbox" data-admin-bulk-table-target="selectAll" id="select-all-seasons" /></td><td>2024</td><td>2025</td><td>2024-2025</td></tr>'
+                                    : ""
+                            }
+                            ${rowMarkup}
+                        </tbody>
+                    </table>`
+                        : ""
+                }
+            </div>
+        `;
+
+        window.__rhStimulusShowConfirmDelete = jest.fn();
+
+        dataTableApi = {
+            destroy: jest.fn(),
+        };
+        dataTableFactory = jest.fn((options) => {
+            if (options && typeof options.drawCallback === "function") {
+                capturedOptions = options;
+            }
+            return dataTableApi;
+        });
+
+        pagination = {
+            hide: jest.fn(),
+            show: jest.fn(),
+        };
+
+        jQueryMock = jest.fn((arg) => {
+            if (arg && arg.__dtContainer === true) {
+                return {
+                    find: jest.fn(() => pagination),
+                };
+            }
+
+            return {
+                DataTable: dataTableFactory,
+            };
+        });
+        jQueryMock.fn = {
+            DataTable: function () {
+                return null;
+            },
+        };
+        jQueryMock.fn.DataTable.isDataTable = jest.fn(() => false);
+
+        window.jQuery = jQueryMock;
+        window.$ = jQueryMock;
+
+        application = Application.start();
+        application.register("admin-bulk-table", AdminBulkTableController);
+
+        const root = document.querySelector(
+            '[data-controller="admin-bulk-table"]',
+        );
+
+        return {
+            getController: async () => {
+                for (let i = 0; i < 4; i += 1) {
+                    const controller =
+                        application.getControllerForElementAndIdentifier(
+                            root,
+                            "admin-bulk-table",
+                        ) ||
+                        application.controllers.find(
+                            (item) => item.identifier === "admin-bulk-table",
+                        );
+
+                    if (controller) {
+                        return controller;
+                    }
+
+                    await Promise.resolve();
+                }
+
+                return undefined;
+            },
+        };
+    };
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        capturedOptions = null;
+    });
+
+    afterEach(() => {
+        if (application) {
+            application.stop();
+            application = null;
+        }
+
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+
+        delete window.__rhStimulusShowConfirmDelete;
+        delete window.jQuery;
+        delete window.$;
+        document.body.innerHTML = "";
+    });
+
+    test("disconnect and jQuery fallback branches handle optional targets and timers", async () => {
+        const mounted = startController();
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        const clearTimeoutSpy = jest.spyOn(window, "clearTimeout");
+        controller.initTimer = 11;
+        controller.retryTimer = 22;
+        controller.disconnect();
+
+        expect(clearTimeoutSpy).toHaveBeenCalledWith(11);
+        expect(clearTimeoutSpy).toHaveBeenCalledWith(22);
+
+        const noBulkFormMounted = startController({ includeBulkForm: false });
+        jest.advanceTimersByTime(0);
+        const noBulkFormController = await noBulkFormMounted.getController();
+        noBulkFormController.initTimer = null;
+        noBulkFormController.retryTimer = null;
+        expect(() => noBulkFormController.disconnect()).not.toThrow();
+
+        window.jQuery = null;
+        window.$ = { marker: "fallback" };
+        expect(noBulkFormController.jQueryHandle()).toEqual({
+            marker: "fallback",
+        });
+
+        clearTimeoutSpy.mockRestore();
+    });
+
+    test("initWhenReady covers no-table, retries, max guard, and available path", async () => {
+        const noTableMounted = startController({ includeTable: false });
+        jest.advanceTimersByTime(0);
+        const noTableController = await noTableMounted.getController();
+
+        const setTimeoutSpy = jest.spyOn(window, "setTimeout");
+        noTableController.initWhenReady();
+        expect(setTimeoutSpy).not.toHaveBeenCalled();
+
+        const mounted = startController();
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        const availSpy = jest
+            .spyOn(controller, "isDataTablesAvailable")
+            .mockReturnValue(false);
+
+        setTimeoutSpy.mockClear();
+        controller.retryCount = 0;
+        controller.initWhenReady();
+        expect(controller.retryCount).toBe(1);
+        expect(setTimeoutSpy).toHaveBeenCalled();
+
+        if (controller.retryTimer) {
+            window.clearTimeout(controller.retryTimer);
+            controller.retryTimer = null;
+        }
+
+        setTimeoutSpy.mockClear();
+        controller.retryCount = 60;
+        controller.initWhenReady();
+        expect(setTimeoutSpy).not.toHaveBeenCalled();
+
+        availSpy.mockRestore();
+        setTimeoutSpy.mockRestore();
+    });
+
+    test("initTable covers guard returns, existing DataTable, draw callback pagination, and order fallbacks", async () => {
+        const mounted = startController();
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        window.jQuery = null;
+        window.$ = null;
+        expect(() => controller.initTable()).not.toThrow();
+
+        window.jQuery = jQueryMock;
+        window.$ = jQueryMock;
+
+        const existing = { id: "existing" };
+        dataTableFactory.mockImplementationOnce(() => existing);
+        jQueryMock.fn.DataTable.isDataTable = jest.fn(() => true);
+        controller.initTable();
+        expect(controller.dtInstance).toBe(existing);
+
+        jQueryMock.fn.DataTable.isDataTable = jest.fn(() => false);
+        controller.initTable();
+        expect(capturedOptions).toBeTruthy();
+
+        const containerRef = { __dtContainer: true };
+        capturedOptions.drawCallback.call({
+            api: () => ({
+                page: { info: () => ({ pages: 1 }) },
+                table: () => ({ container: () => containerRef }),
+            }),
+        });
+        expect(pagination.hide).toHaveBeenCalled();
+
+        capturedOptions.drawCallback.call({
+            api: () => ({
+                page: { info: () => ({ pages: 3 }) },
+                table: () => ({ container: () => containerRef }),
+            }),
+        });
+        expect(pagination.show).toHaveBeenCalled();
+
+        const noOrderMounted = startController({
+            includeOrderColumnValue: false,
+        });
+        jest.advanceTimersByTime(0);
+        const noOrderController = await noOrderMounted.getController();
+        dataTableFactory.mockClear();
+        noOrderController.initTable();
+        expect(dataTableFactory.mock.calls[0][0].order).toBeUndefined();
+
+        const noDirectionMounted = startController({
+            includeOrderDirectionValue: false,
+        });
+        jest.advanceTimersByTime(0);
+        const noDirectionController = await noDirectionMounted.getController();
+        dataTableFactory.mockClear();
+        noDirectionController.initTable();
+        expect(dataTableFactory.mock.calls[0][0].order).toEqual([[1, "asc"]]);
+    });
+
+    test("destroyTable handles null, successful destroy, and destroy exceptions", async () => {
+        const mounted = startController();
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        controller.dtInstance = null;
+        expect(() => controller.destroyTable()).not.toThrow();
+
+        controller.dtInstance = {
+            destroy: jest.fn(),
+        };
+        controller.destroyTable();
+        expect(controller.dtInstance).toBeNull();
+
+        controller.dtInstance = {
+            destroy: jest.fn(() => {
+                throw new Error("stale");
+            }),
+        };
+        expect(() => controller.destroyTable()).not.toThrow();
+        expect(controller.dtInstance).toBeNull();
+    });
+
+    test("onChange and updateBulkButtonState cover guard and select-all branches", async () => {
+        const mounted = startController();
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        const updateSpy = jest.spyOn(controller, "updateBulkButtonState");
+        controller.selectAllTarget.checked = true;
+        controller.onChange({ target: controller.selectAllTarget });
+        expect(
+            controller
+                .rowCheckboxes()
+                .every((checkbox) => checkbox.checked === true),
+        ).toBe(true);
+
+        controller.onChange({ target: controller.actionSelectTarget });
+        controller.onChange({ target: controller.rowCheckboxes()[0] });
+        controller.onChange({ target: document.createElement("button") });
+
+        expect(updateSpy).toHaveBeenCalledTimes(3);
+        updateSpy.mockRestore();
+
+        const noButtonMounted = startController({ includeActionButton: false });
+        jest.advanceTimersByTime(0);
+        const noButtonController = await noButtonMounted.getController();
+        expect(() => noButtonController.updateBulkButtonState()).not.toThrow();
+    });
+
+    test("onSubmit guards and extractRowName branches include helper availability and missing row/cell", async () => {
+        const mounted = startController();
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        const event = { preventDefault: jest.fn() };
+        controller.actionSelectTarget.value = "";
+        controller.onSubmit(event);
+        expect(window.__rhStimulusShowConfirmDelete).not.toHaveBeenCalled();
+
+        controller.actionSelectTarget.value = "archive";
+        controller.onSubmit(event);
+        expect(window.__rhStimulusShowConfirmDelete).not.toHaveBeenCalled();
+
+        controller.actionSelectTarget.value = "delete";
+        controller.onSubmit(event);
+        expect(window.__rhStimulusShowConfirmDelete).not.toHaveBeenCalled();
+
+        controller.rowCheckboxes()[0].checked = true;
+        const originalBridge = window.__rhStimulusShowConfirmDelete;
+        window.__rhStimulusShowConfirmDelete = undefined;
+        controller.onSubmit(event);
+        expect(originalBridge).not.toHaveBeenCalled();
+
+        window.__rhStimulusShowConfirmDelete = jest.fn();
+        controller.onSubmit(event);
+        expect(window.__rhStimulusShowConfirmDelete).toHaveBeenCalledWith(
+            expect.objectContaining({
+                ids: ["10"],
+                associated: ["2023-2024"],
+            }),
+        );
+
+        const orphanCheckbox = document.createElement("input");
+        orphanCheckbox.type = "checkbox";
+        orphanCheckbox.value = "999";
+        expect(controller.extractRowName(orphanCheckbox)).toBe("");
+
+        const row = document.createElement("tr");
+        const firstCell = document.createElement("td");
+        firstCell.textContent = "Ignore";
+        const secondCell = document.createElement("td");
+        secondCell.textContent = "Name Value";
+        row.appendChild(firstCell);
+        row.appendChild(secondCell);
+        const nestedCheckbox = document.createElement("input");
+        row.appendChild(nestedCheckbox);
+
+        const noNameValue =
+            AdminBulkTableController.prototype.extractRowName.call(
+                {
+                    hasNameColumnValue: false,
+                },
+                nestedCheckbox,
+            );
+        expect(noNameValue).toBe("Name Value");
+
+        const missingCell =
+            AdminBulkTableController.prototype.extractRowName.call(
+                {
+                    hasNameColumnValue: true,
+                    nameColumnValue: 5,
+                },
+                nestedCheckbox,
+            );
+        expect(missingCell).toBe("");
+    });
+});

--- a/js/tests/admin_confirm_delete_controller.test.js
+++ b/js/tests/admin_confirm_delete_controller.test.js
@@ -9,6 +9,29 @@ describe("admin-confirm-delete controller", () => {
     let showSpy;
     let requestSubmitMock;
 
+    const getController = async () => {
+        const root = document.getElementById("confirm-delete-modal");
+
+        for (let i = 0; i < 4; i += 1) {
+            const controller =
+                application.getControllerForElementAndIdentifier(
+                    root,
+                    "admin-confirm-delete",
+                ) ||
+                application.controllers.find(
+                    (item) => item.identifier === "admin-confirm-delete",
+                );
+
+            if (controller) {
+                return controller;
+            }
+
+            await Promise.resolve();
+        }
+
+        return undefined;
+    };
+
     beforeEach(() => {
         document.body.innerHTML = `
             <div
@@ -138,5 +161,238 @@ describe("admin-confirm-delete controller", () => {
         expect(tempForm.querySelector('input[name="bulk_action"]').value).toBe(
             "delete",
         );
+    });
+
+    test("ignores onShow without related target and prefers deleteAssociated", async () => {
+        const controller = await getController();
+        const setContextSpy = jest.spyOn(controller, "setContext");
+        const modal = document.getElementById("confirm-delete-modal");
+
+        modal.dispatchEvent(new Event("show.bs.modal"));
+        expect(setContextSpy).not.toHaveBeenCalled();
+
+        const trigger = document.createElement("button");
+        trigger.dataset.associated = '["Fallback"]';
+        trigger.dataset.deleteAssociated = '["Preferred"]';
+        trigger.dataset.deleteUrl = "/admin/anything/delete/1";
+        const showEvent = new Event("show.bs.modal");
+        showEvent.relatedTarget = trigger;
+        modal.dispatchEvent(showEvent);
+
+        expect(controller.modalContext.associated).toBe('["Preferred"]');
+
+        setContextSpy.mockRestore();
+    });
+
+    test("open falls back to display block without bootstrap and defaults empty context", async () => {
+        const controller = await getController();
+        delete global.bootstrap;
+
+        controller.element.style.display = "";
+        controller.open();
+
+        expect(controller.modalContext).toEqual({});
+        expect(controller.element.style.display).toBe("block");
+    });
+
+    test("disconnect only removes bridge when handler matches", async () => {
+        const controller = await getController();
+        const otherHandler = () => {};
+
+        window.__rhStimulusShowConfirmDelete = otherHandler;
+        controller.disconnect();
+        expect(window.__rhStimulusShowConfirmDelete).toBe(otherHandler);
+
+        window.__rhStimulusShowConfirmDelete = controller.globalShowHandler;
+        controller.disconnect();
+        expect(window.__rhStimulusShowConfirmDelete).toBeUndefined();
+    });
+
+    test("renderAssociated handles object label, name, and JSON fallback values", async () => {
+        const controller = await getController();
+
+        controller.renderAssociated([
+            { label: "Label value" },
+            { name: "Name value" },
+            { foo: "bar" },
+            "Plain value",
+        ]);
+
+        const values = Array.from(controller.associatedTarget.children).map(
+            (node) => node.textContent,
+        );
+        expect(values).toEqual([
+            "Label value",
+            "Name value",
+            '{"foo":"bar"}',
+            "Plain value",
+        ]);
+
+        expect(() =>
+            AdminConfirmDeleteController.prototype.renderAssociated.call(
+                { hasAssociatedTarget: false },
+                ["unused"],
+            ),
+        ).not.toThrow();
+    });
+
+    test("parseAssociated and normalizeIds cover JSON, numeric, and fallback cases", async () => {
+        const controller = await getController();
+
+        expect(controller.parseAssociated(null)).toEqual([]);
+        expect(controller.parseAssociated(["a", "b"])).toEqual(["a", "b"]);
+        expect(controller.parseAssociated('{"id":1}')).toEqual([{ id: 1 }]);
+        expect(controller.parseAssociated("not-json")).toEqual(["not-json"]);
+
+        expect(controller.normalizeIds([1, 2])).toEqual([1, 2]);
+        expect(controller.normalizeIds("[3,4]")).toEqual([3, 4]);
+        expect(controller.normalizeIds('{"id":9}')).toEqual([{ id: 9 }]);
+        expect(controller.normalizeIds("null")).toEqual([]);
+        expect(controller.normalizeIds(" +42 ")).toEqual([42]);
+        expect(controller.normalizeIds("abc")).toEqual([]);
+        expect(controller.normalizeIds(5)).toEqual([5]);
+        expect(controller.normalizeIds(0)).toEqual([]);
+    });
+
+    test("resolveSourceForm and resolvePostAction handle hidden target and catch fallback", async () => {
+        const controller = await getController();
+        const source = document.getElementById("delete-form-seasons-bulk");
+
+        controller.modalContext = { formId: "delete-form-seasons-bulk" };
+        expect(controller.resolveSourceForm()).toBe(source);
+
+        controller.modalContext = {};
+        expect(controller.resolveSourceForm()).toBe(
+            controller.hiddenFormTarget,
+        );
+        expect(controller.resolvePostAction(null)).toBe("#");
+
+        source.setAttribute("action", "/admin/seasons/custom-action");
+        controller.modalContext = { deleteUrl: "/admin/fallback-action" };
+        expect(controller.resolvePostAction(source)).toContain(
+            "/admin/seasons/custom-action",
+        );
+
+        const throwingSource = {
+            getAttribute() {
+                throw new Error("attr failure");
+            },
+        };
+        expect(controller.resolvePostAction(throwingSource)).toBe(
+            "/admin/fallback-action",
+        );
+
+        const noHidden =
+            AdminConfirmDeleteController.prototype.resolveSourceForm.call({
+                modalContext: {},
+                hasHiddenFormTarget: false,
+            });
+        expect(noHidden).toBeNull();
+    });
+
+    test("submitSourceForm removes injected fields and uses submit fallback", async () => {
+        const controller = await getController();
+        const source = document.getElementById("delete-form-seasons-bulk");
+        const stale = document.createElement("input");
+        stale.type = "hidden";
+        stale.name = "stale";
+        stale.className = "injected-delete";
+        source.appendChild(stale);
+
+        const submitSpy = jest.fn();
+        source.requestSubmit = undefined;
+        source.submit = submitSpy;
+
+        controller.submitSourceForm(source, "/admin/seasons/new-action", [
+            { name: "season_ids[]", value: "7" },
+        ]);
+
+        expect(source.action).toContain("/admin/seasons/new-action");
+        expect(source.querySelector('input[name="stale"]')).toBeNull();
+        expect(source.querySelector('input[name="season_ids[]"]').value).toBe(
+            "7",
+        );
+        expect(submitSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("submitTempForm clones hidden values and uses submit fallback when requestSubmit is unavailable", async () => {
+        const controller = await getController();
+        const hiddenForm = document.getElementById(
+            "confirm-delete-modal-hidden-form",
+        );
+        const blankHidden = document.createElement("input");
+        blankHidden.type = "hidden";
+        blankHidden.name = "blank-token";
+        blankHidden.value = "";
+        hiddenForm.appendChild(blankHidden);
+
+        const originalRequestSubmit = HTMLFormElement.prototype.requestSubmit;
+        const originalSubmit = HTMLFormElement.prototype.submit;
+        const submitSpy = jest.fn();
+
+        Object.defineProperty(HTMLFormElement.prototype, "requestSubmit", {
+            configurable: true,
+            writable: true,
+            value: undefined,
+        });
+        Object.defineProperty(HTMLFormElement.prototype, "submit", {
+            configurable: true,
+            writable: true,
+            value: submitSpy,
+        });
+
+        controller.submitTempForm("/admin/temp-action", [
+            { name: "user_ids[]", value: "13" },
+        ]);
+
+        const forms = Array.from(document.querySelectorAll("form"));
+        const tempForm = forms[forms.length - 1];
+
+        expect(tempForm.action).toContain("/admin/temp-action");
+        expect(tempForm.querySelector('input[name="_csrfToken"]').value).toBe(
+            "test-token",
+        );
+        expect(tempForm.querySelector('input[name="blank-token"]').value).toBe(
+            "",
+        );
+        expect(tempForm.querySelector('input[name="user_ids[]"]').value).toBe(
+            "13",
+        );
+        expect(submitSpy).toHaveBeenCalledTimes(1);
+
+        Object.defineProperty(HTMLFormElement.prototype, "requestSubmit", {
+            configurable: true,
+            writable: true,
+            value: originalRequestSubmit,
+        });
+        Object.defineProperty(HTMLFormElement.prototype, "submit", {
+            configurable: true,
+            writable: true,
+            value: originalSubmit,
+        });
+    });
+
+    test("buildExtraFields handles missing ids and filtered id payloads", async () => {
+        const controller = await getController();
+
+        controller.modalContext = { bulkAction: "archive" };
+        expect(controller.buildExtraFields()).toEqual([
+            { name: "bulk_action", value: "archive" },
+        ]);
+
+        controller.modalContext = {};
+        expect(controller.buildExtraFields()).toEqual([]);
+
+        controller.modalContext = {
+            ids: '["", " 5 ", null, "slug-2"]',
+            idsName: "season_ids[]",
+            bulkAction: "delete",
+        };
+
+        expect(controller.buildExtraFields()).toEqual([
+            { name: "season_ids[]", value: "5" },
+            { name: "season_ids[]", value: "slug-2" },
+            { name: "bulk_action", value: "delete" },
+        ]);
     });
 });

--- a/js/tests/admin_games_index_controller.test.js
+++ b/js/tests/admin_games_index_controller.test.js
@@ -170,3 +170,288 @@ describe("admin-games-index controller", () => {
         expect(dataTableApi.destroy).not.toHaveBeenCalled();
     });
 });
+
+describe("admin-games-index controller branch coverage", () => {
+    let application;
+    let jQueryMock;
+    let dataTableFactory;
+    let dataTableApi;
+
+    const renderFixture = ({
+        includeTableTarget = true,
+        includeBulkFormTarget = true,
+        includeSelectAllTarget = true,
+        includeActionTargets = true,
+    } = {}) => {
+        document.body.innerHTML = `
+            <div
+                data-controller="admin-games-index"
+                data-admin-games-index-ajax-url-value="/admin/games/ajaxList"
+                data-admin-games-index-bulk-delete-url-value="/admin/games/bulk"
+                data-admin-games-index-delete-form-id-value="delete-form-games-bulk"
+            >
+                <form id="bulk-action-form-games" ${includeBulkFormTarget ? 'data-admin-games-index-target="bulkForm"' : ""}>
+                    <select id="bulk-action-select" ${includeActionTargets ? 'data-admin-games-index-target="actionSelect"' : ""}>
+                        <option value="">Choose...</option>
+                        <option value="delete">Delete</option>
+                    </select>
+                    <button id="bulk-action-btn" ${includeActionTargets ? 'data-admin-games-index-target="actionButton"' : ""} disabled type="submit">
+                        Go
+                    </button>
+                </form>
+
+                <table id="games-table" ${includeTableTarget ? 'data-admin-games-index-target="table"' : ""}>
+                    <thead>
+                        <tr>
+                            <th>
+                                <input
+                                    id="select-all-games"
+                                    ${includeSelectAllTarget ? 'data-admin-games-index-target="selectAll"' : ""}
+                                    type="checkbox"
+                                />
+                            </th>
+                            <th>Date</th>
+                            <th>Team Season</th>
+                            <th>H/R/N</th>
+                            <th>Opponent</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><input class="game-checkbox" type="checkbox" value="1" /></td>
+                            <td>2024-01-10</td>
+                            <td>Racers 2023-2024</td>
+                            <td>H</td>
+                            <td>Belmont</td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <form id="delete-form-games-bulk"></form>
+            </div>
+        `;
+    };
+
+    const startController = async (options = {}) => {
+        if (application) {
+            application.stop();
+            application = null;
+        }
+
+        renderFixture(options);
+
+        application = Application.start();
+        application.register("admin-games-index", AdminGamesIndexController);
+
+        const root = document.querySelector(
+            '[data-controller="admin-games-index"]',
+        );
+        for (let i = 0; i < 4; i += 1) {
+            const controller =
+                application.getControllerForElementAndIdentifier(
+                    root,
+                    "admin-games-index",
+                ) ||
+                application.controllers.find(
+                    (item) => item.identifier === "admin-games-index",
+                );
+            if (controller) {
+                return controller;
+            }
+
+            await Promise.resolve();
+        }
+
+        return undefined;
+    };
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+
+        dataTableApi = {
+            settings: jest.fn(() => [
+                { jqXHR: { readyState: 1, abort: jest.fn() } },
+            ]),
+            destroy: jest.fn(),
+        };
+        dataTableFactory = jest.fn(() => dataTableApi);
+
+        jQueryMock = jest.fn(() => ({
+            DataTable: dataTableFactory,
+        }));
+        jQueryMock.fn = {
+            DataTable: function DataTable() {
+                return null;
+            },
+            dataTable: {
+                SearchBuilder: function SearchBuilder() {
+                    return null;
+                },
+            },
+        };
+        jQueryMock.fn.DataTable.isDataTable = jest.fn(() => false);
+
+        window.jQuery = jQueryMock;
+        window.$ = jQueryMock;
+        window.__rhStimulusShowConfirmDelete = jest.fn();
+    });
+
+    afterEach(() => {
+        if (application) {
+            application.stop();
+            application = null;
+        }
+
+        delete window.__rhStimulusShowConfirmDelete;
+        delete window.jQuery;
+        delete window.$;
+        document.body.innerHTML = "";
+        jest.restoreAllMocks();
+        jest.useRealTimers();
+    });
+
+    test("retry/disconnect branches and helper fallbacks", async () => {
+        const controller = await startController({ includeTableTarget: false });
+
+        expect(controller.jQueryHandle()).toBe(jQueryMock);
+        delete window.jQuery;
+        expect(controller.jQueryHandle()).toBe(jQueryMock);
+        delete window.$;
+        expect(controller.jQueryHandle()).toBeNull();
+        expect(controller.isDataTablesAvailable()).toBe(false);
+        expect(controller.hasRequiredExtensions()).toBe(false);
+
+        window.$ = jQueryMock;
+        controller.retryCount = 60;
+        controller.initWhenReady();
+        expect(controller.retryTimer).toBeNull();
+
+        controller.retryCount = 0;
+        controller.initWhenReady();
+        expect(controller.retryCount).toBe(1);
+        expect(controller.retryTimer).not.toBeNull();
+
+        const earlyController = await startController();
+        expect(earlyController.initTimer).not.toBeNull();
+        earlyController.disconnect();
+        expect(earlyController.initTimer).toBeNull();
+    });
+
+    test("initTable existing instance and missing dependency guards", async () => {
+        const controller = await startController();
+        jest.advanceTimersByTime(0);
+
+        jQueryMock.fn.DataTable.isDataTable.mockReturnValue(true);
+        controller.initTable();
+        expect(dataTableFactory).toHaveBeenCalled();
+
+        delete window.jQuery;
+        delete window.$;
+        expect(() => controller.initTable()).not.toThrow();
+
+        const noTableController = await startController({
+            includeTableTarget: false,
+        });
+        expect(() => noTableController.initTable()).not.toThrow();
+    });
+
+    test("destroyTable handles abort/no-abort and stale instance exceptions", async () => {
+        const controller = await startController();
+
+        controller.dtInstance = null;
+        controller.destroyTable();
+
+        const pendingAbort = jest.fn();
+        controller.dtInstance = {
+            settings: jest.fn(() => [
+                { jqXHR: { readyState: 1, abort: pendingAbort } },
+            ]),
+            destroy: jest.fn(),
+        };
+        controller.destroyTable();
+        expect(pendingAbort).toHaveBeenCalledTimes(1);
+
+        const finalizedAbort = jest.fn();
+        const finalizedDestroy = jest.fn();
+        controller.dtInstance = {
+            settings: jest.fn(() => [
+                { jqXHR: { readyState: 4, abort: finalizedAbort } },
+            ]),
+            destroy: finalizedDestroy,
+        };
+        controller.destroyTable();
+        expect(finalizedAbort).not.toHaveBeenCalled();
+        expect(finalizedDestroy).toHaveBeenCalledWith(false);
+
+        controller.dtInstance = {
+            settings: jest.fn(() => {
+                throw new Error("stale settings");
+            }),
+            destroy: jest.fn(() => {
+                throw new Error("stale destroy");
+            }),
+        };
+        expect(() => controller.destroyTable()).not.toThrow();
+        expect(controller.dtInstance).toBeNull();
+    });
+
+    test("onChange/onSubmit/update state guard matrix", async () => {
+        const controller = await startController();
+        jest.advanceTimersByTime(0);
+
+        const updateSpy = jest.spyOn(controller, "updateBulkButtonState");
+        controller.onChange({ target: document.createElement("div") });
+        expect(updateSpy).not.toHaveBeenCalled();
+
+        const actionSelect = document.getElementById("bulk-action-select");
+        controller.onChange({ target: actionSelect });
+        expect(updateSpy).toHaveBeenCalled();
+
+        const submitEvent = {
+            preventDefault: jest.fn(),
+        };
+
+        actionSelect.value = "";
+        controller.onSubmit(submitEvent);
+        expect(submitEvent.preventDefault).toHaveBeenCalled();
+        expect(window.__rhStimulusShowConfirmDelete).not.toHaveBeenCalled();
+
+        actionSelect.value = "delete";
+        controller.onSubmit(submitEvent);
+        expect(window.__rhStimulusShowConfirmDelete).not.toHaveBeenCalled();
+
+        const rowCheckbox = document.querySelector(".game-checkbox");
+        rowCheckbox.checked = true;
+
+        const savedConfirm = window.__rhStimulusShowConfirmDelete;
+        delete window.__rhStimulusShowConfirmDelete;
+        controller.onSubmit(submitEvent);
+        expect(savedConfirm).not.toHaveBeenCalled();
+        window.__rhStimulusShowConfirmDelete = savedConfirm;
+
+        const detached = document.createElement("input");
+        detached.className = "game-checkbox";
+        detached.type = "checkbox";
+        detached.value = "44";
+        detached.checked = true;
+        controller.element.appendChild(detached);
+        controller.onSubmit(submitEvent);
+        expect(window.__rhStimulusShowConfirmDelete).toHaveBeenCalledWith(
+            expect.objectContaining({
+                ids: expect.arrayContaining(["44"]),
+                associated: expect.arrayContaining([""]),
+            }),
+        );
+
+        const noActionTargetsController = await startController({
+            includeActionTargets: false,
+        });
+        expect(() =>
+            noActionTargetsController.updateBulkButtonState(),
+        ).not.toThrow();
+
+        expect(() =>
+            noActionTargetsController.onSubmit({ preventDefault: jest.fn() }),
+        ).not.toThrow();
+    });
+});

--- a/js/tests/admin_image_bulk_upload_controller.test.js
+++ b/js/tests/admin_image_bulk_upload_controller.test.js
@@ -109,4 +109,324 @@ describe("admin-image-bulk-upload controller", () => {
         expect(fetch.mock.calls.length).toBeGreaterThanOrEqual(1);
         expect(fetch.mock.calls[0][0]).toContain("/admin/images/bulk-upload");
     });
+
+    test("shows an error when no files are selected", async () => {
+        document.getElementById("uploadAll").removeAttribute("disabled");
+        document.getElementById("uploadAll").click();
+        await flushPromises();
+        await flushPromises();
+
+        expect(global.fetch).not.toHaveBeenCalled();
+        expect(document.getElementById("uploadStatus").textContent).toContain(
+            "Please choose at least one image file.",
+        );
+    });
+
+    test("shows a warning when some chunk uploads fail", async () => {
+        fetch
+            .mockResolvedValueOnce({
+                headers: { get: () => "application/json" },
+                json: async () => ({
+                    results: [{ success: true, name: "first.png" }],
+                }),
+            })
+            .mockResolvedValueOnce({
+                headers: { get: () => "application/json" },
+                json: async () => ({
+                    results: [
+                        {
+                            success: false,
+                            name: "third.png",
+                            error: "Failed validation",
+                        },
+                    ],
+                }),
+            });
+
+        const input = document.getElementById("uploads");
+        const files = [
+            new File(["a"], "first.png", { type: "image/png" }),
+            new File(["b"], "second.png", { type: "image/png" }),
+            new File(["c"], "third.png", { type: "image/png" }),
+        ];
+        Object.defineProperty(input, "files", {
+            configurable: true,
+            value: files,
+        });
+        input.dispatchEvent(new Event("change", { bubbles: true }));
+
+        document.getElementById("uploadAll").click();
+        await flushPromises();
+        await flushPromises();
+        await flushPromises();
+
+        expect(document.getElementById("uploadStatus").textContent).toContain(
+            "Some images uploaded; some failed.",
+        );
+        expect(document.getElementById("uploadStatus").innerHTML).toContain(
+            "Failed validation",
+        );
+    });
+
+    test("reports non-json and unexpected upload errors", async () => {
+        fetch
+            .mockResolvedValueOnce({
+                headers: { get: () => "text/html" },
+                status: 413,
+                text: async () => "<html>payload too large</html>",
+            })
+            .mockRejectedValueOnce(new Error("boom"));
+
+        const input = document.getElementById("uploads");
+        const files = [
+            new File(["a"], "first.png", { type: "image/png" }),
+            new File(["b"], "second.png", { type: "image/png" }),
+        ];
+        Object.defineProperty(input, "files", {
+            configurable: true,
+            value: files,
+        });
+        input.dispatchEvent(new Event("change", { bubbles: true }));
+
+        document.getElementById("uploadAll").click();
+        await flushPromises();
+
+        expect(document.getElementById("uploadStatus").textContent).toContain(
+            "Upload request was too large for the server.",
+        );
+
+        document.getElementById("uploadAll").click();
+        await flushPromises();
+
+        expect(document.getElementById("uploadStatus").textContent).toContain(
+            "Unexpected error while uploading.",
+        );
+    });
+});
+
+describe("admin-image-bulk-upload controller branch coverage", () => {
+    let application;
+
+    const renderFixture = ({
+        includeFormTarget = true,
+        includeUploadsInputTarget = true,
+        includeFileListTarget = true,
+        includeUploadButtonTarget = true,
+        includeUploadStatusTarget = true,
+        includeButtonLabelTarget = true,
+        includeButtonSpinnerTarget = true,
+        chunkSizeValue = "2",
+        includeActionAttribute = true,
+    } = {}) => {
+        document.body.innerHTML = `
+            <form
+                id="bulkUploadForm"
+                ${includeActionAttribute ? 'action="/admin/images/bulk-upload"' : ""}
+                data-controller="admin-image-bulk-upload"
+                ${includeFormTarget ? 'data-admin-image-bulk-upload-target="form"' : ""}
+                data-admin-image-bulk-upload-chunk-size-value="${chunkSizeValue}"
+            >
+                <input
+                    type="file"
+                    id="uploads"
+                    name="uploads[]"
+                    multiple
+                    ${includeUploadsInputTarget ? 'data-admin-image-bulk-upload-target="uploadsInput"' : ""}
+                    data-action="change->admin-image-bulk-upload#fileSelectionChanged"
+                />
+                <div id="fileList" ${includeFileListTarget ? 'data-admin-image-bulk-upload-target="fileList"' : ""}></div>
+                <button
+                    id="uploadAll"
+                    type="button"
+                    disabled
+                    ${includeUploadButtonTarget ? 'data-admin-image-bulk-upload-target="uploadButton"' : ""}
+                    data-action="click->admin-image-bulk-upload#uploadAll"
+                >
+                    <span class="label" ${includeButtonLabelTarget ? 'data-admin-image-bulk-upload-target="buttonLabel"' : ""}>Upload Selected</span>
+                    <span class="spinner-border d-none" ${includeButtonSpinnerTarget ? 'data-admin-image-bulk-upload-target="buttonSpinner"' : ""}></span>
+                </button>
+                <div id="uploadStatus" ${includeUploadStatusTarget ? 'data-admin-image-bulk-upload-target="uploadStatus"' : ""}></div>
+            </form>
+        `;
+    };
+
+    const startController = async (options = {}) => {
+        if (application) {
+            application.stop();
+            application = null;
+        }
+
+        renderFixture(options);
+
+        application = Application.start();
+        application.register(
+            "admin-image-bulk-upload",
+            AdminImageBulkUploadController,
+        );
+
+        const root = document.querySelector(
+            '[data-controller="admin-image-bulk-upload"]',
+        );
+        for (let i = 0; i < 4; i += 1) {
+            const controller =
+                application.getControllerForElementAndIdentifier(
+                    root,
+                    "admin-image-bulk-upload",
+                ) ||
+                application.controllers.find(
+                    (item) => item.identifier === "admin-image-bulk-upload",
+                );
+            if (controller) {
+                return controller;
+            }
+
+            await Promise.resolve();
+        }
+
+        return undefined;
+    };
+
+    beforeEach(() => {
+        global.fetch = jest.fn();
+    });
+
+    afterEach(() => {
+        if (application) {
+            application.stop();
+            application = null;
+        }
+
+        jest.restoreAllMocks();
+        delete global.fetch;
+        document.body.innerHTML = "";
+    });
+
+    test("file selection/change and render guard branches", async () => {
+        const controller = await startController({
+            includeFileListTarget: false,
+            includeUploadButtonTarget: false,
+        });
+
+        expect(() =>
+            controller.fileSelectionChanged({ target: {} }),
+        ).not.toThrow();
+        expect(() => controller.renderFileRows([])).not.toThrow();
+        expect(controller.currentFiles()).toEqual([]);
+    });
+
+    test("chunk size/default helpers and status/detail guards", async () => {
+        const controller = await startController({
+            includeUploadsInputTarget: false,
+            includeUploadStatusTarget: false,
+            includeUploadButtonTarget: false,
+            includeButtonLabelTarget: false,
+            includeButtonSpinnerTarget: false,
+            chunkSizeValue: "0",
+        });
+
+        expect(controller.chunkSize).toBe(3);
+        expect(controller.currentFiles()).toEqual([]);
+        expect(() => controller.setUploadingState(true)).not.toThrow();
+        expect(() => controller.setUploadingState(false)).not.toThrow();
+        expect(() => controller.showStatus("danger", "hidden")).not.toThrow();
+        expect(controller.buildDetails([])).toBe("");
+
+        const details = controller.buildDetails([
+            { success: true, existing: true },
+            { success: false, name: "bad.png", error: "invalid" },
+        ]);
+        expect(details).toContain("unnamed");
+        expect(details).toContain("(duplicate)");
+        expect(details).toContain("invalid");
+    });
+
+    test("uploadAll handles danger and non-413 non-json branches", async () => {
+        await startController();
+
+        const input = document.getElementById("uploads");
+        const files = [new File(["a"], "first.png", { type: "image/png" })];
+        Object.defineProperty(input, "files", {
+            configurable: true,
+            value: files,
+        });
+        input.dispatchEvent(new Event("change", { bubbles: true }));
+
+        fetch.mockResolvedValueOnce({
+            headers: { get: () => "application/json" },
+            json: async () => ({
+                results: [{ success: false, name: "first.png", error: "bad" }],
+            }),
+        });
+        document.getElementById("uploadAll").click();
+        await flushPromises();
+        await flushPromises();
+        expect(document.getElementById("uploadStatus").textContent).toContain(
+            "Upload failed.",
+        );
+
+        fetch.mockResolvedValueOnce({
+            headers: { get: () => "application/json" },
+            json: async () => ({
+                error: "chunk failure",
+            }),
+        });
+        document.getElementById("uploadAll").click();
+        await flushPromises();
+        await flushPromises();
+        expect(document.getElementById("uploadStatus").innerHTML).toContain(
+            "batch-1",
+        );
+
+        fetch.mockResolvedValueOnce({
+            headers: { get: () => "text/html" },
+            status: 500,
+            text: async () => "<html>server error</html>",
+        });
+        document.getElementById("uploadAll").click();
+        await flushPromises();
+        expect(document.getElementById("uploadStatus").textContent).toContain(
+            "Server returned invalid response",
+        );
+    });
+
+    test("uploadChunk fallback action and non-json metadata branches", async () => {
+        const controller = await startController({
+            includeFormTarget: false,
+            includeActionAttribute: false,
+        });
+
+        fetch.mockResolvedValueOnce({
+            headers: { get: () => "text/html; charset=utf-8" },
+            status: 500,
+            text: async () => "x".repeat(700),
+        });
+
+        await expect(
+            controller.uploadChunk(
+                [new File(["a"], "first.png", { type: "image/png" })],
+                3,
+            ),
+        ).rejects.toEqual(
+            expect.objectContaining({
+                name: "NonJsonResponseError",
+                status: 500,
+                chunkIndex: 3,
+            }),
+        );
+        expect(fetch.mock.calls[0][0]).toContain("/admin/images/bulk-upload");
+
+        fetch.mockResolvedValueOnce({
+            headers: { get: () => "APPLICATION/JSON" },
+            json: async () => ({
+                results: [{ success: true, name: "ok.png" }],
+            }),
+        });
+
+        await expect(
+            controller.uploadChunk(
+                [new File(["b"], "second.png", { type: "image/png" })],
+                4,
+            ),
+        ).resolves.toEqual({ results: [{ success: true, name: "ok.png" }] });
+    });
 });

--- a/js/tests/admin_image_crop_thumb_controller.test.js
+++ b/js/tests/admin_image_crop_thumb_controller.test.js
@@ -4,16 +4,41 @@ import { Application } from "@hotwired/stimulus";
 
 import AdminImageCropThumbController from "../controllers/admin_image_crop_thumb_controller.js";
 
+const createCanvasContext = () => ({
+    clearRect: jest.fn(),
+    drawImage: jest.fn(),
+});
+
+const flush = () => Promise.resolve().then(() => Promise.resolve());
+
 describe("admin-image-crop-thumb controller", () => {
     let application;
     let originalGetContext;
 
-    beforeEach(() => {
-        originalGetContext = HTMLCanvasElement.prototype.getContext;
-        HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
-            clearRect: jest.fn(),
-            drawImage: jest.fn(),
-        }));
+    function renderFixture({
+        includePreviewCanvas = true,
+        includeCropFields = true,
+        imageWidth = 300,
+        imageHeight = 300,
+        canvasContext = createCanvasContext(),
+    } = {}) {
+        if (!originalGetContext) {
+            originalGetContext = HTMLCanvasElement.prototype.getContext;
+        }
+        HTMLCanvasElement.prototype.getContext = jest.fn(() => canvasContext);
+
+        const cropFields = includeCropFields
+            ? `
+                <input id="crop_x" data-admin-image-crop-thumb-target="cropX" />
+                <input id="crop_y" data-admin-image-crop-thumb-target="cropY" />
+                <input id="crop_width" data-admin-image-crop-thumb-target="cropWidth" />
+                <input id="crop_height" data-admin-image-crop-thumb-target="cropHeight" />
+            `
+            : "";
+
+        const previewCanvas = includePreviewCanvas
+            ? '<canvas id="preview-canvas" width="150" height="150" data-admin-image-crop-thumb-target="previewCanvas"></canvas>'
+            : "";
 
         document.body.innerHTML = `
             <div data-controller="admin-image-crop-thumb">
@@ -23,11 +48,8 @@ describe("admin-image-crop-thumb controller", () => {
                         <div class="resize-handle" data-admin-image-crop-thumb-target="resizeHandle"></div>
                     </div>
                 </div>
-                <canvas id="preview-canvas" width="150" height="150" data-admin-image-crop-thumb-target="previewCanvas"></canvas>
-                <input id="crop_x" data-admin-image-crop-thumb-target="cropX" />
-                <input id="crop_y" data-admin-image-crop-thumb-target="cropY" />
-                <input id="crop_width" data-admin-image-crop-thumb-target="cropWidth" />
-                <input id="crop_height" data-admin-image-crop-thumb-target="cropHeight" />
+                ${previewCanvas}
+                ${cropFields}
                 <button id="reset" data-action="click->admin-image-crop-thumb#reset" type="button">Reset</button>
             </div>
         `;
@@ -45,12 +67,12 @@ describe("admin-image-crop-thumb controller", () => {
         });
 
         image.getBoundingClientRect = () => ({
-            width: 300,
-            height: 300,
+            width: imageWidth,
+            height: imageHeight,
             top: 0,
             left: 0,
-            right: 300,
-            bottom: 300,
+            right: imageWidth,
+            bottom: imageHeight,
         });
         container.getBoundingClientRect = () => ({
             width: 300,
@@ -66,6 +88,12 @@ describe("admin-image-crop-thumb controller", () => {
             "admin-image-crop-thumb",
             AdminImageCropThumbController,
         );
+
+        return { image, container };
+    }
+
+    beforeEach(() => {
+        renderFixture();
     });
 
     afterEach(() => {
@@ -100,5 +128,153 @@ describe("admin-image-crop-thumb controller", () => {
         );
         expect(width).toBeGreaterThan(0);
         expect(height).toBeGreaterThan(0);
+    });
+
+    test("returns early when required targets are missing", () => {
+        application.stop();
+        application = null;
+
+        renderFixture({ includePreviewCanvas: false });
+
+        expect(document.getElementById("crop_width")).not.toBeNull();
+        expect(document.getElementById("crop_width").value).toBe("");
+        expect(document.getElementById("crop-overlay").style.display).toBe(
+            "none",
+        );
+    });
+
+    test("does not initialize crop when the image has no measured size", () => {
+        application.stop();
+        application = null;
+
+        renderFixture({ imageWidth: 0, imageHeight: 0 });
+
+        expect(document.getElementById("crop_width").value).toBe("");
+        expect(document.getElementById("crop-overlay").style.display).toBe(
+            "none",
+        );
+    });
+
+    test("handles drag, resize, detached move, and idle mousemove paths", () => {
+        const container = document.getElementById("crop-container");
+        const resizeHandle = document.querySelector(".resize-handle");
+        const overlay = document.getElementById("crop-overlay");
+
+        document.dispatchEvent(
+            new window.MouseEvent("mousemove", {
+                bubbles: true,
+                clientX: 5,
+                clientY: 5,
+            }),
+        );
+
+        resizeHandle.dispatchEvent(
+            new window.MouseEvent("mousedown", {
+                bubbles: true,
+                clientX: 280,
+                clientY: 280,
+            }),
+        );
+        document.dispatchEvent(
+            new window.MouseEvent("mousemove", {
+                bubbles: true,
+                clientX: 10,
+                clientY: 10,
+            }),
+        );
+
+        expect(overlay.style.width).toBe("20px");
+        expect(overlay.style.height).toBe("20px");
+
+        document.dispatchEvent(
+            new window.MouseEvent("mouseup", { bubbles: true }),
+        );
+
+        container.dispatchEvent(
+            new window.MouseEvent("mousedown", {
+                bubbles: true,
+                clientX: 10,
+                clientY: 10,
+            }),
+        );
+        document.dispatchEvent(
+            new window.MouseEvent("mousemove", {
+                bubbles: true,
+                clientX: 60,
+                clientY: 70,
+            }),
+        );
+
+        expect(overlay.style.left).toBe("50px");
+        expect(overlay.style.top).toBe("60px");
+
+        document.dispatchEvent(
+            new window.MouseEvent("mouseup", { bubbles: true }),
+        );
+
+        container.dispatchEvent(
+            new window.MouseEvent("mousedown", {
+                bubbles: true,
+                clientX: 100,
+                clientY: 100,
+            }),
+        );
+        const containsSpy = jest
+            .spyOn(document.body, "contains")
+            .mockReturnValue(false);
+        document.dispatchEvent(
+            new window.MouseEvent("mousemove", {
+                bubbles: true,
+                clientX: 120,
+                clientY: 130,
+            }),
+        );
+        containsSpy.mockRestore();
+
+        expect(overlay.style.left).toBe("50px");
+        expect(overlay.style.top).toBe("60px");
+    });
+
+    test("skips preview drawing when the canvas context is unavailable or the image is incomplete", async () => {
+        application.stop();
+        application = null;
+
+        renderFixture({ canvasContext: null });
+        await flush();
+
+        expect(document.getElementById("crop_width").value).toBe("300");
+        expect(document.getElementById("crop-overlay").style.display).toBe(
+            "block",
+        );
+
+        application.stop();
+        application = null;
+
+        const { image } = renderFixture();
+        await flush();
+        Object.defineProperty(image, "complete", {
+            configurable: true,
+            value: false,
+        });
+
+        document.getElementById("reset").click();
+
+        expect(document.getElementById("crop-overlay").style.display).toBe(
+            "block",
+        );
+    });
+
+    test("omits optional crop fields when they are not present", async () => {
+        application.stop();
+        application = null;
+
+        renderFixture({ includeCropFields: false });
+        await flush();
+
+        expect(document.querySelector("#crop_x")).toBeNull();
+        expect(document.querySelector("#crop-overlay")).not.toBeNull();
+        expect(document.getElementById("crop-overlay").style.display).toBe(
+            "block",
+        );
     });
 });

--- a/js/tests/admin_index_table_controller.test.js
+++ b/js/tests/admin_index_table_controller.test.js
@@ -270,3 +270,374 @@ describe("admin-index-table controller (game-types local table)", () => {
         expect(drawMock).toHaveBeenCalledTimes(1);
     });
 });
+
+describe("admin-index-table controller branch coverage", () => {
+    let application;
+    let dataTableApi;
+    let dataTableFactory;
+    let jQueryMock;
+    let pagination;
+    let capturedOptions;
+
+    const startController = ({
+        includeSearch = true,
+        includeTable = true,
+        tableId = "opponents-table",
+        datatablesUrl = "/admin/opponents/datatables",
+    } = {}) => {
+        if (application) {
+            application.stop();
+            application = null;
+        }
+
+        document.body.innerHTML = `
+            <div data-controller="admin-index-table">
+                ${
+                    includeSearch
+                        ? '<input id="branch-search" data-admin-index-table-target="searchInput" value="" />'
+                        : ""
+                }
+                ${
+                    includeTable
+                        ? `<table id="${tableId}" data-admin-index-table-target="table" ${
+                              datatablesUrl
+                                  ? `data-datatables-url="${datatablesUrl}"`
+                                  : ""
+                          }><tbody></tbody></table>`
+                        : ""
+                }
+            </div>
+        `;
+
+        dataTableApi = {
+            destroy: jest.fn(),
+            settings: jest.fn(() => []),
+            search: jest.fn(() => ({ draw: jest.fn() })),
+        };
+        capturedOptions = null;
+        dataTableFactory = jest.fn((options) => {
+            capturedOptions = options;
+            return dataTableApi;
+        });
+
+        pagination = {
+            hide: jest.fn(),
+            show: jest.fn(),
+        };
+
+        jQueryMock = jest.fn((arg) => {
+            if (arg && arg.__dtContainer === true) {
+                return {
+                    find: jest.fn(() => pagination),
+                };
+            }
+
+            return {
+                DataTable: dataTableFactory,
+            };
+        });
+
+        jQueryMock.fn = {
+            DataTable: function () {
+                return null;
+            },
+            dataTable: {
+                Scroller: function () {
+                    return null;
+                },
+            },
+        };
+        jQueryMock.fn.DataTable.isDataTable = jest.fn(() => false);
+
+        window.jQuery = jQueryMock;
+        window.$ = jQueryMock;
+
+        application = Application.start();
+        application.register("admin-index-table", AdminIndexTableController);
+
+        const root = document.querySelector(
+            '[data-controller="admin-index-table"]',
+        );
+
+        return {
+            getController: async () => {
+                for (let i = 0; i < 4; i += 1) {
+                    const resolved =
+                        application.getControllerForElementAndIdentifier(
+                            root,
+                            "admin-index-table",
+                        ) ||
+                        application.controllers.find(
+                            (controller) =>
+                                controller.identifier === "admin-index-table",
+                        );
+
+                    if (resolved) {
+                        return resolved;
+                    }
+
+                    await Promise.resolve();
+                }
+
+                return undefined;
+            },
+        };
+    };
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        if (application) {
+            application.stop();
+            application = null;
+        }
+
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+
+        delete window.jQuery;
+        delete window.$;
+        document.body.innerHTML = "";
+    });
+
+    test("handles missing page config and missing table target guards", async () => {
+        const noTable = startController({ includeTable: false });
+        jest.advanceTimersByTime(0);
+        const noTableController = await noTable.getController();
+
+        expect(noTableController.pageConfig).toBeNull();
+
+        if (noTableController.hasSearchInputTarget) {
+            expect(noTableController.searchInputTarget.placeholder).toBe("");
+        }
+
+        const unknown = startController({ tableId: "unknown-table" });
+        jest.advanceTimersByTime(0);
+        const unknownController = await unknown.getController();
+
+        expect(unknownController.pageConfig).toBeNull();
+    });
+
+    test("jQueryHandle and DataTables availability checks use fallback branches", async () => {
+        const mounted = startController();
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        window.jQuery = null;
+        window.$ = null;
+        expect(controller.jQueryHandle()).toBeNull();
+        expect(controller.isDataTablesAvailable()).toBe(false);
+
+        window.$ = {
+            fn: {
+                DataTable: function () {
+                    return null;
+                },
+            },
+        };
+        expect(controller.jQueryHandle()).toBe(window.$);
+        expect(controller.isDataTablesAvailable()).toBe(true);
+    });
+
+    test("hasRequiredExtensions and initWhenReady retry/max branches", async () => {
+        const mounted = startController();
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        expect(controller.hasRequiredExtensions({ scroller: false })).toBe(
+            true,
+        );
+
+        delete jQueryMock.fn.dataTable.Scroller;
+        expect(controller.hasRequiredExtensions({ scroller: true })).toBe(
+            false,
+        );
+
+        const setTimeoutSpy = jest.spyOn(window, "setTimeout");
+        const initTableSpy = jest.spyOn(controller, "initTable");
+        const availSpy = jest
+            .spyOn(controller, "isDataTablesAvailable")
+            .mockReturnValue(false);
+
+        setTimeoutSpy.mockClear();
+        controller.retryCount = 0;
+        controller.initWhenReady();
+        expect(controller.retryCount).toBe(1);
+        expect(setTimeoutSpy).toHaveBeenCalled();
+
+        setTimeoutSpy.mockClear();
+        controller.retryCount = 60;
+        controller.initWhenReady();
+        expect(setTimeoutSpy).not.toHaveBeenCalled();
+
+        availSpy.mockRestore();
+        initTableSpy.mockRestore();
+        setTimeoutSpy.mockRestore();
+    });
+
+    test("destroyTable handles abort, catches errors, and no-instance guard", async () => {
+        const mounted = startController();
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        controller.dtInstance = {
+            settings: jest.fn(() => [
+                {
+                    jqXHR: {
+                        readyState: 2,
+                        abort: jest.fn(),
+                    },
+                },
+            ]),
+            destroy: jest.fn(),
+        };
+
+        controller.destroyTable();
+        expect(controller.dtInstance).toBeNull();
+
+        const aborting = {
+            readyState: 2,
+            abort: jest.fn(() => {
+                throw new Error("abort failed");
+            }),
+        };
+        controller.dtInstance = {
+            settings: jest.fn(() => [{ jqXHR: aborting }]),
+            destroy: jest.fn(() => {
+                throw new Error("destroy failed");
+            }),
+        };
+
+        expect(() => controller.destroyTable()).not.toThrow();
+        expect(controller.dtInstance).toBeNull();
+
+        controller.dtInstance = null;
+        expect(() => controller.destroyTable()).not.toThrow();
+    });
+
+    test("initTable handles guard returns, existing table, dataUrl missing, and callback pagination", async () => {
+        const mounted = startController();
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        window.jQuery = null;
+        window.$ = null;
+        expect(() => controller.initTable()).not.toThrow();
+
+        window.jQuery = jQueryMock;
+        window.$ = jQueryMock;
+
+        jQueryMock.fn.DataTable.isDataTable = jest.fn(() => true);
+        const existing = { id: "existing" };
+        dataTableFactory.mockReturnValue(existing);
+        controller.initTable();
+        expect(controller.dtInstance).toBe(existing);
+
+        jQueryMock.fn.DataTable.isDataTable = jest.fn(() => false);
+        const noUrl = startController({ datatablesUrl: "" });
+        jest.advanceTimersByTime(0);
+        const noUrlController = await noUrl.getController();
+
+        dataTableFactory.mockClear();
+        noUrlController.initTable();
+        expect(dataTableFactory).not.toHaveBeenCalled();
+
+        const draw = startController({ tableId: "team-seasons-table" });
+        jest.advanceTimersByTime(0);
+        const drawController = await draw.getController();
+
+        drawController.initTable();
+        expect(capturedOptions).toBeTruthy();
+        const containerRef = { __dtContainer: true };
+
+        capturedOptions.drawCallback.call({
+            api: () => ({
+                page: { info: () => ({ pages: 1 }) },
+                table: () => ({ container: () => containerRef }),
+            }),
+        });
+        expect(pagination.hide).toHaveBeenCalled();
+
+        capturedOptions.drawCallback.call({
+            api: () => ({
+                page: { info: () => ({ pages: 4 }) },
+                table: () => ({ container: () => containerRef }),
+            }),
+        });
+        expect(pagination.show).toHaveBeenCalled();
+    });
+
+    test("initTable default option fallbacks and handleSearchInput guard/debounce branches", async () => {
+        const mounted = startController({ tableId: "team-seasons-table" });
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        const pageConfigSpy = jest
+            .spyOn(controller, "pageConfig", "get")
+            .mockReturnValue({
+                labelPlural: "rows",
+                order: [[0, "asc"]],
+                serverSide: false,
+            });
+
+        dataTableFactory.mockClear();
+        controller.initTable();
+
+        expect(capturedOptions.pageLength).toBe(50);
+        expect(capturedOptions.lengthMenu).toEqual([25, 50, 100, 250]);
+        expect(capturedOptions.scrollCollapse).toBe(true);
+        expect(capturedOptions.deferRender).toBe(true);
+        expect(capturedOptions.dom).toBe("rltip");
+
+        pageConfigSpy.mockRestore();
+
+        controller.dtInstance = null;
+        expect(() => controller.handleSearchInput()).not.toThrow();
+
+        controller.dtInstance = dataTableApi;
+        controller.searchDebounce = window.setTimeout(() => {}, 1000);
+        controller.searchInputTarget.value = "branch";
+        controller.handleSearchInput();
+        jest.advanceTimersByTime(250);
+        expect(dataTableApi.search).toHaveBeenCalledWith("branch");
+
+        dataTableApi.search.mockClear();
+        controller.dtInstance = null;
+        controller.handleSearchInput();
+        jest.advanceTimersByTime(250);
+        expect(dataTableApi.search).not.toHaveBeenCalled();
+    });
+
+    test("disconnect clears timers and removes search listener safely", async () => {
+        const mounted = startController();
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        const removeSpy = jest.spyOn(
+            controller.searchInputTarget,
+            "removeEventListener",
+        );
+
+        controller.initTimer = window.setTimeout(() => {}, 1000);
+        controller.searchDebounce = window.setTimeout(() => {}, 1000);
+        controller.retryTimer = window.setTimeout(() => {}, 1000);
+        controller.disconnect();
+
+        expect(removeSpy).toHaveBeenCalledWith(
+            "input",
+            controller.boundSearchInput,
+        );
+        expect(controller.initTimer).toBeNull();
+        expect(controller.searchDebounce).toBeNull();
+        expect(controller.retryTimer).toBeNull();
+
+        removeSpy.mockRestore();
+
+        const noSearch = startController({ includeSearch: false });
+        jest.advanceTimersByTime(0);
+        const noSearchController = await noSearch.getController();
+        expect(() => noSearchController.disconnect()).not.toThrow();
+    });
+});

--- a/js/tests/admin_users_index_controller.test.js
+++ b/js/tests/admin_users_index_controller.test.js
@@ -179,3 +179,423 @@ describe("admin-users-index controller", () => {
         expect(dataTableApi.destroy).not.toHaveBeenCalled();
     });
 });
+
+describe("admin-users-index controller branch coverage", () => {
+    let application;
+    let dataTableApi;
+    let dataTableFactory;
+    let jQueryMock;
+    let pagination;
+    let capturedOptions;
+
+    const startController = ({
+        includeBulkForm = true,
+        includePendingTable = true,
+        includeSearchTable = true,
+        includeActionSelect = true,
+        includeActionButton = true,
+        includeSelectAll = true,
+        includeRows = true,
+    } = {}) => {
+        const selectAllCell = includeSelectAll
+            ? '<input id="select-all-users" data-admin-users-index-target="selectAll" type="checkbox" />'
+            : "";
+        const rowMarkup = includeRows
+            ? `
+                <tr>
+                    <td><input class="user-checkbox" data-admin-users-index-role="row-checkbox" name="user_ids[]" type="checkbox" value="2" /></td>
+                    <td>new_user</td>
+                </tr>
+                <tr>
+                    <td><input class="user-checkbox" data-admin-users-index-role="row-checkbox" name="user_ids[]" type="checkbox" value="9" /></td>
+                </tr>
+              `
+            : "";
+
+        document.body.innerHTML = `
+            <div
+                data-controller="admin-users-index"
+                data-admin-users-index-bulk-activate-url-value="/admin/users/bulkActivate"
+                data-admin-users-index-bulk-delete-url-value="/admin/users/bulkDelete"
+                data-admin-users-index-delete-form-id-value="delete-form-users-bulk"
+            >
+                ${
+                    includeBulkForm
+                        ? `<form id="bulk-action-form" data-admin-users-index-target="bulkForm">
+                    ${
+                        includeActionSelect
+                            ? `<select id="bulk-action-select" data-admin-users-index-target="actionSelect">
+                                <option value="">Choose...</option>
+                                <option value="approve">Approve</option>
+                                <option value="delete">Delete</option>
+                                <option value="noop">No-op</option>
+                            </select>`
+                            : ""
+                    }
+                    ${
+                        includeActionButton
+                            ? '<button id="bulk-action-btn" data-admin-users-index-target="actionButton" disabled type="submit">Go</button>'
+                            : ""
+                    }
+                </form>`
+                        : ""
+                }
+
+                ${
+                    includePendingTable
+                        ? `<table id="users-table" data-admin-users-index-target="pendingTable">
+                    <thead>
+                        <tr>
+                            <th>${selectAllCell}</th>
+                            <th>Username</th>
+                        </tr>
+                    </thead>
+                    <tbody>${rowMarkup}</tbody>
+                </table>`
+                        : ""
+                }
+
+                ${
+                    includeSearchTable
+                        ? `<table id="search-users-table" data-admin-users-index-target="searchTable"><tbody><tr><td>admin</td></tr></tbody></table>`
+                        : ""
+                }
+            </div>
+        `;
+
+        dataTableApi = {
+            destroy: jest.fn(),
+            search: jest.fn(() => dataTableApi),
+            draw: jest.fn(),
+        };
+        dataTableFactory = jest.fn((options) => {
+            if (options && typeof options.drawCallback === "function") {
+                capturedOptions = options;
+            }
+            return dataTableApi;
+        });
+
+        pagination = {
+            hide: jest.fn(),
+            show: jest.fn(),
+        };
+
+        jQueryMock = jest.fn((arg) => {
+            if (arg && arg.__dtContainer === true) {
+                return {
+                    find: jest.fn(() => pagination),
+                };
+            }
+
+            return {
+                DataTable: dataTableFactory,
+            };
+        });
+        jQueryMock.fn = {
+            DataTable: function () {
+                return null;
+            },
+        };
+        jQueryMock.fn.DataTable.isDataTable = jest.fn(() => false);
+
+        window.__rhStimulusShowConfirmDelete = jest.fn();
+        window.jQuery = jQueryMock;
+        window.$ = jQueryMock;
+
+        application = Application.start();
+        application.register("admin-users-index", AdminUsersIndexController);
+
+        const root = document.querySelector(
+            '[data-controller="admin-users-index"]',
+        );
+
+        return {
+            getController: async () => {
+                for (let i = 0; i < 4; i += 1) {
+                    const controller =
+                        application.getControllerForElementAndIdentifier(
+                            root,
+                            "admin-users-index",
+                        ) ||
+                        application.controllers.find(
+                            (item) => item.identifier === "admin-users-index",
+                        );
+
+                    if (controller) {
+                        return controller;
+                    }
+
+                    await Promise.resolve();
+                }
+
+                return undefined;
+            },
+        };
+    };
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        capturedOptions = null;
+    });
+
+    afterEach(() => {
+        if (application) {
+            application.stop();
+            application = null;
+        }
+
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+
+        delete window.__rhStimulusShowConfirmDelete;
+        delete window.jQuery;
+        delete window.$;
+        document.body.innerHTML = "";
+    });
+
+    test("connect/disconnect and DataTables readiness retries cover guard branches", async () => {
+        const mounted = startController({ includeBulkForm: false });
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        window.jQuery = null;
+        window.$ = null;
+        expect(controller.jQueryHandle()).toBeNull();
+        expect(controller.isDataTablesAvailable()).toBe(false);
+
+        window.$ = {
+            fn: {
+                DataTable: function () {
+                    return null;
+                },
+            },
+        };
+        window.$.fn.DataTable.isDataTable = () => false;
+        expect(controller.jQueryHandle()).toBe(window.$);
+        expect(controller.isDataTablesAvailable()).toBe(true);
+
+        const setTimeoutSpy = jest.spyOn(window, "setTimeout");
+        const availableSpy = jest
+            .spyOn(controller, "isDataTablesAvailable")
+            .mockReturnValue(false);
+
+        controller.retryCount = 0;
+        controller.initWhenReady();
+        expect(controller.retryCount).toBe(1);
+        expect(setTimeoutSpy).toHaveBeenCalled();
+
+        if (controller.retryTimer) {
+            window.clearTimeout(controller.retryTimer);
+            controller.retryTimer = null;
+        }
+
+        setTimeoutSpy.mockClear();
+        controller.retryCount = 60;
+        controller.initWhenReady();
+        expect(setTimeoutSpy).not.toHaveBeenCalled();
+
+        availableSpy.mockRestore();
+        setTimeoutSpy.mockRestore();
+
+        window.jQuery = jQueryMock;
+        window.$ = jQueryMock;
+
+        const clearTimeoutSpy = jest.spyOn(window, "clearTimeout");
+        controller.initTimer = 101;
+        controller.retryTimer = 202;
+        controller.disconnect();
+
+        expect(clearTimeoutSpy).toHaveBeenCalledWith(101);
+        expect(clearTimeoutSpy).toHaveBeenCalledWith(202);
+        expect(controller.initTimer).toBeNull();
+        expect(controller.retryTimer).toBeNull();
+
+        clearTimeoutSpy.mockRestore();
+    });
+
+    test("initTables and initTable cover jq guards, existing table, and draw callback pagination", async () => {
+        const mounted = startController({
+            includePendingTable: false,
+            includeSearchTable: false,
+        });
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        const initTableSpy = jest.spyOn(controller, "initTable");
+
+        window.jQuery = null;
+        window.$ = null;
+        controller.initTables();
+
+        window.jQuery = jQueryMock;
+        window.$ = jQueryMock;
+        controller.initTables();
+        expect(initTableSpy).not.toHaveBeenCalled();
+
+        const table = document.createElement("table");
+        const existing = { id: "existing" };
+        dataTableFactory.mockImplementationOnce(() => existing);
+        jQueryMock.fn.DataTable.isDataTable = jest.fn(() => true);
+        expect(controller.initTable(table, jQueryMock)).toBe(existing);
+
+        jQueryMock.fn.DataTable.isDataTable = jest.fn(() => false);
+        controller.initTable(table, jQueryMock);
+        expect(capturedOptions).toBeTruthy();
+
+        const containerRef = { __dtContainer: true };
+        capturedOptions.drawCallback.call({
+            api: () => ({
+                page: { info: () => ({ pages: 1 }) },
+                table: () => ({ container: () => containerRef }),
+            }),
+        });
+        expect(pagination.hide).toHaveBeenCalled();
+
+        capturedOptions.drawCallback.call({
+            api: () => ({
+                page: { info: () => ({ pages: 3 }) },
+                table: () => ({ container: () => containerRef }),
+            }),
+        });
+        expect(pagination.show).toHaveBeenCalled();
+
+        initTableSpy.mockRestore();
+    });
+
+    test("destroyTables handles null and stale instances safely", async () => {
+        const mounted = startController();
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        controller.pendingDt = null;
+        controller.searchDt = {
+            destroy: jest.fn(() => {
+                throw new Error("stale table");
+            }),
+        };
+
+        expect(() => controller.destroyTables()).not.toThrow();
+        expect(controller.pendingDt).toBeNull();
+        expect(controller.searchDt).toBeNull();
+    });
+
+    test("onChange covers select-all, action-select, row checkbox, and no bulk form guards", async () => {
+        const mounted = startController();
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        const updateSpy = jest.spyOn(controller, "updateBulkButtonState");
+        const rowCheckboxes = controller.rowCheckboxes();
+
+        controller.selectAllTarget.checked = true;
+        controller.onChange({ target: controller.selectAllTarget });
+        expect(rowCheckboxes.every((checkbox) => checkbox.checked)).toBe(true);
+
+        controller.onChange({ target: controller.actionSelectTarget });
+        controller.onChange({ target: rowCheckboxes[0] });
+
+        const unrelated = document.createElement("button");
+        controller.onChange({ target: unrelated });
+
+        expect(updateSpy).toHaveBeenCalledTimes(3);
+        updateSpy.mockRestore();
+
+        const noBulkMounted = startController({ includeBulkForm: false });
+        jest.advanceTimersByTime(0);
+        const noBulkController = await noBulkMounted.getController();
+        const noBulkUpdateSpy = jest.spyOn(
+            noBulkController,
+            "updateBulkButtonState",
+        );
+
+        noBulkController.onChange({ target: document.createElement("div") });
+        expect(noBulkUpdateSpy).not.toHaveBeenCalled();
+
+        noBulkUpdateSpy.mockRestore();
+    });
+
+    test("onSubmit covers missing target guards and approve/delete/noop branches", async () => {
+        const guardMounted = startController({ includeBulkForm: false });
+        jest.advanceTimersByTime(0);
+        const guardController = await guardMounted.getController();
+        const guardEvent = { preventDefault: jest.fn() };
+        guardController.onSubmit(guardEvent);
+        expect(guardEvent.preventDefault).toHaveBeenCalled();
+
+        const mounted = startController();
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+        const event = { preventDefault: jest.fn() };
+
+        controller.actionSelectTarget.value = "";
+        controller.onSubmit(event);
+        expect(window.__rhStimulusShowConfirmDelete).not.toHaveBeenCalled();
+
+        controller.actionSelectTarget.value = "approve";
+        controller.bulkFormTarget.requestSubmit = jest.fn();
+        controller.bulkFormTarget.submit = jest.fn();
+        controller.onSubmit(event);
+        expect(controller.bulkFormTarget.requestSubmit).toHaveBeenCalledTimes(
+            1,
+        );
+
+        controller.bulkFormTarget.requestSubmit = undefined;
+        controller.onSubmit(event);
+        expect(controller.bulkFormTarget.submit).toHaveBeenCalledTimes(1);
+
+        controller.actionSelectTarget.value = "noop";
+        controller.onSubmit(event);
+        expect(window.__rhStimulusShowConfirmDelete).not.toHaveBeenCalled();
+
+        controller.actionSelectTarget.value = "delete";
+        controller.rowCheckboxes().forEach((checkbox) => {
+            checkbox.checked = false;
+        });
+        controller.onSubmit(event);
+        expect(window.__rhStimulusShowConfirmDelete).not.toHaveBeenCalled();
+
+        controller.rowCheckboxes().forEach((checkbox) => {
+            checkbox.checked = true;
+        });
+        const originalDeleteBridge = window.__rhStimulusShowConfirmDelete;
+        window.__rhStimulusShowConfirmDelete = undefined;
+        controller.onSubmit(event);
+        expect(originalDeleteBridge).not.toHaveBeenCalled();
+
+        window.__rhStimulusShowConfirmDelete = jest.fn();
+        controller.onSubmit(event);
+        expect(window.__rhStimulusShowConfirmDelete).toHaveBeenCalledWith(
+            expect.objectContaining({
+                ids: ["2", "9"],
+                associated: ["new_user", ""],
+                idsName: "user_ids[]",
+                bulkAction: "delete",
+            }),
+        );
+    });
+
+    test("updateBulkButtonState handles guard and enabled/disabled transitions", async () => {
+        const noButtonMounted = startController({ includeActionButton: false });
+        jest.advanceTimersByTime(0);
+        const noButtonController = await noButtonMounted.getController();
+        expect(() => noButtonController.updateBulkButtonState()).not.toThrow();
+
+        const noRowsMounted = startController({ includeRows: false });
+        jest.advanceTimersByTime(0);
+        const noRowsController = await noRowsMounted.getController();
+        expect(noRowsController.rowCheckboxes()).toEqual([]);
+
+        const mounted = startController();
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        controller.actionSelectTarget.value = "";
+        controller.updateBulkButtonState();
+        expect(controller.actionButtonTarget.disabled).toBe(true);
+
+        controller.rowCheckboxes()[0].checked = true;
+        controller.actionSelectTarget.value = "approve";
+        controller.updateBulkButtonState();
+        expect(controller.actionButtonTarget.disabled).toBe(false);
+    });
+});

--- a/js/tests/blog_post_form_controller.test.js
+++ b/js/tests/blog_post_form_controller.test.js
@@ -1,4 +1,4 @@
-/* global afterEach, beforeEach, describe, expect, jest, test */
+/* global Blob, afterEach, beforeEach, describe, expect, jest, test */
 
 import { Application } from "@hotwired/stimulus";
 
@@ -9,9 +9,37 @@ describe("blog-post-form controller", () => {
     let tinymceInitMock;
     let tinymceRemoveMock;
     let tinymceGetMock;
+    let originalXmlHttpRequest;
+
+    const getController = async () => {
+        const root = document.querySelector(
+            '[data-controller="blog-post-form"]',
+        );
+
+        for (let i = 0; i < 4; i += 1) {
+            const controller =
+                application.getControllerForElementAndIdentifier(
+                    root,
+                    "blog-post-form",
+                ) ||
+                application.controllers.find(
+                    (item) => item.identifier === "blog-post-form",
+                );
+
+            if (controller) {
+                return controller;
+            }
+
+            await Promise.resolve();
+        }
+
+        return undefined;
+    };
 
     beforeEach(() => {
+        originalXmlHttpRequest = window.XMLHttpRequest;
         document.body.innerHTML = `
+            <meta name="csrfToken" content="csrf-token" />
             <div
                 data-controller="blog-post-form"
                 data-blog-post-form-existing-hero-id-value="12"
@@ -47,6 +75,7 @@ describe("blog-post-form controller", () => {
             application = null;
         }
 
+        window.XMLHttpRequest = originalXmlHttpRequest;
         delete window.tinymce;
         document.body.innerHTML = "";
     });
@@ -100,5 +129,375 @@ describe("blog-post-form controller", () => {
         expect(tinymceRemoveMock).not.toHaveBeenCalled();
         document.dispatchEvent(new Event("turbo:before-cache"));
         expect(tinymceRemoveMock).toHaveBeenCalled();
+    });
+
+    test("uses existing hero image when field starts empty and supports unset button", () => {
+        const heroField = document.getElementById("hero-image-field");
+        const heroPreview = document.getElementById("hero-image-preview");
+        const heroVariantBtn = document.getElementById("hero-variant-btn");
+        const unsetHeroBtn = document.getElementById("unset-hero-btn");
+
+        expect(heroField.value).toBe("12");
+        expect(heroPreview.style.display).toBe("block");
+        expect(heroPreview.querySelector("img").src).toContain(
+            "/img/storage/12-hero.jpg",
+        );
+        expect(heroVariantBtn.getAttribute("href")).toBe(
+            "/admin/images/crop-hero/12",
+        );
+
+        unsetHeroBtn.click();
+
+        expect(heroField.value).toBe("");
+        expect(heroPreview.style.display).toBe("none");
+        expect(heroVariantBtn.style.display).toBe("none");
+        expect(unsetHeroBtn.style.display).toBe("none");
+    });
+
+    test("handles inline image guard branches when id/url/editor are unavailable", () => {
+        const inlineField = document.getElementById("inline-image-field");
+
+        inlineField.value = "abc";
+        inlineField.dataset.selectedImageUrl = "/img/storage/abc.jpg";
+        inlineField.dispatchEvent(new Event("change", { bubbles: true }));
+
+        inlineField.value = "7";
+        delete inlineField.dataset.selectedImageUrl;
+        inlineField.dispatchEvent(new Event("change", { bubbles: true }));
+
+        inlineField.value = "7";
+        inlineField.dataset.selectedImageUrl = "/img/storage/7.jpg";
+        delete window.tinymce.activeEditor;
+        inlineField.dispatchEvent(new Event("change", { bubbles: true }));
+
+        expect(inlineField.value).toBe("7");
+        expect(inlineField.dataset.selectedImageUrl).toBe("/img/storage/7.jpg");
+    });
+
+    test("handles TinyMCE upload success and error branches", async () => {
+        const initConfig = tinymceInitMock.mock.calls[0][0];
+        const blobInfo = {
+            blob: () => new Blob(["img"], { type: "image/jpeg" }),
+            filename: () => "hero.jpg",
+        };
+
+        const successXhr = {
+            upload: {},
+            headers: {},
+            open: jest.fn(),
+            setRequestHeader: jest.fn((key, value) => {
+                successXhr.headers[key] = value;
+            }),
+            send: jest.fn((formData) => {
+                successXhr.upload.onprogress({
+                    lengthComputable: true,
+                    loaded: 3,
+                    total: 6,
+                });
+                successXhr.formData = formData;
+                successXhr.onload();
+            }),
+            status: 200,
+            responseText: JSON.stringify({
+                success: true,
+                image: { url: "/img/storage/hero.jpg" },
+            }),
+        };
+
+        window.XMLHttpRequest = jest.fn(() => successXhr);
+        const progress = jest.fn();
+
+        await expect(
+            initConfig.images_upload_handler(blobInfo, progress),
+        ).resolves.toBe("/img/storage/hero.jpg");
+        expect(progress).toHaveBeenCalledWith(50);
+        expect(successXhr.open).toHaveBeenCalledWith(
+            "POST",
+            "/admin/images/upload",
+        );
+        expect(successXhr.headers["X-CSRF-Token"]).toBe("csrf-token");
+        expect(successXhr.formData.get("upload")).toBeInstanceOf(Blob);
+
+        const httpErrorXhr = {
+            upload: {},
+            open: jest.fn(),
+            setRequestHeader: jest.fn(),
+            send: jest.fn(() => httpErrorXhr.onload()),
+            status: 500,
+            responseText: "",
+        };
+        window.XMLHttpRequest = jest.fn(() => httpErrorXhr);
+        await expect(
+            initConfig.images_upload_handler(blobInfo, jest.fn()),
+        ).rejects.toBe("HTTP Error: 500");
+
+        const invalidJsonXhr = {
+            upload: {},
+            open: jest.fn(),
+            setRequestHeader: jest.fn(),
+            send: jest.fn(() => invalidJsonXhr.onload()),
+            status: 200,
+            responseText: "not-json",
+        };
+        window.XMLHttpRequest = jest.fn(() => invalidJsonXhr);
+        await expect(
+            initConfig.images_upload_handler(blobInfo, jest.fn()),
+        ).rejects.toBe("Invalid JSON");
+
+        const uploadErrorXhr = {
+            upload: {},
+            open: jest.fn(),
+            setRequestHeader: jest.fn(),
+            send: jest.fn(() => uploadErrorXhr.onload()),
+            status: 200,
+            responseText: JSON.stringify({ success: false, error: "Nope" }),
+        };
+        window.XMLHttpRequest = jest.fn(() => uploadErrorXhr);
+        await expect(
+            initConfig.images_upload_handler(blobInfo, jest.fn()),
+        ).rejects.toBe("Nope");
+
+        const networkErrorXhr = {
+            upload: {},
+            open: jest.fn(),
+            setRequestHeader: jest.fn(),
+            send: jest.fn(() => networkErrorXhr.onerror()),
+            status: 200,
+            responseText: "",
+        };
+        window.XMLHttpRequest = jest.fn(() => networkErrorXhr);
+        await expect(
+            initConfig.images_upload_handler(blobInfo, jest.fn()),
+        ).rejects.toBe("Image upload failed");
+    });
+
+    test("connect and disconnect cover optional target guards and timer cleanup", () => {
+        const clearTimeoutSpy = jest
+            .spyOn(window, "clearTimeout")
+            .mockImplementation(() => {});
+
+        const fake = {
+            hasHeroFieldTarget: false,
+            hasUnsetHeroButtonTarget: false,
+            hasInlineFieldTarget: false,
+            updateHeroImageState: jest.fn(),
+            initTinyMceWhenReady: jest.fn(),
+            destroyTinyMCE: jest.fn(),
+        };
+
+        BlogPostFormController.prototype.connect.call(fake);
+        expect(fake.updateHeroImageState).toHaveBeenCalledTimes(1);
+        expect(fake.initTinyMceWhenReady).toHaveBeenCalledTimes(1);
+
+        fake.tinyMceRetryTimer = 123;
+        BlogPostFormController.prototype.disconnect.call(fake);
+        expect(clearTimeoutSpy).toHaveBeenCalledWith(123);
+        expect(fake.destroyTinyMCE).toHaveBeenCalledTimes(1);
+
+        const fakeNoTimer = {
+            hasHeroFieldTarget: false,
+            hasUnsetHeroButtonTarget: false,
+            hasInlineFieldTarget: false,
+            updateHeroImageState: jest.fn(),
+            initTinyMceWhenReady: jest.fn(),
+            destroyTinyMCE: jest.fn(),
+        };
+        BlogPostFormController.prototype.connect.call(fakeNoTimer);
+        fakeNoTimer.tinyMceRetryTimer = null;
+        BlogPostFormController.prototype.disconnect.call(fakeNoTimer);
+        expect(fakeNoTimer.destroyTinyMCE).toHaveBeenCalledTimes(1);
+
+        clearTimeoutSpy.mockRestore();
+    });
+
+    test("connect hero target initialization branches handle empty and prefilled values", () => {
+        const makeFake = (existingHeroId, heroValue) => ({
+            hasHeroFieldTarget: true,
+            heroFieldTarget: {
+                value: heroValue,
+                addEventListener: jest.fn(),
+                removeEventListener: jest.fn(),
+            },
+            existingHeroIdValue: existingHeroId,
+            hasUnsetHeroButtonTarget: false,
+            hasInlineFieldTarget: false,
+            updateHeroImageState: jest.fn(),
+            initTinyMceWhenReady: jest.fn(),
+        });
+
+        const fillsEmpty = makeFake(12, "");
+        BlogPostFormController.prototype.connect.call(fillsEmpty);
+        expect(fillsEmpty.heroFieldTarget.value).toBe("12");
+
+        const keepsPrefilled = makeFake(12, "22");
+        BlogPostFormController.prototype.connect.call(keepsPrefilled);
+        expect(keepsPrefilled.heroFieldTarget.value).toBe("22");
+
+        const skipsWhenExistingNotPositive = makeFake(0, "");
+        BlogPostFormController.prototype.connect.call(
+            skipsWhenExistingNotPositive,
+        );
+        expect(skipsWhenExistingNotPositive.heroFieldTarget.value).toBe("");
+    });
+
+    test("initTinyMceWhenReady covers no-editor, missing-id, retry, and existing-editor branches", () => {
+        expect(() =>
+            BlogPostFormController.prototype.initTinyMceWhenReady.call({
+                hasEditorTarget: false,
+            }),
+        ).not.toThrow();
+
+        expect(() =>
+            BlogPostFormController.prototype.initTinyMceWhenReady.call({
+                hasEditorTarget: true,
+                editorTarget: { id: "" },
+            }),
+        ).not.toThrow();
+
+        const setTimeoutSpy = jest
+            .spyOn(window, "setTimeout")
+            .mockImplementation(() => 987);
+        const retryContext = {
+            hasEditorTarget: true,
+            editorTarget: { id: "body-editor" },
+            tinyMceRetryCount: 0,
+            tinyMceRetryTimer: null,
+            initTinyMceWhenReady: jest.fn(),
+        };
+
+        const originalTinymce = window.tinymce;
+        delete window.tinymce;
+        BlogPostFormController.prototype.initTinyMceWhenReady.call(
+            retryContext,
+        );
+        expect(retryContext.tinyMceRetryCount).toBe(1);
+        expect(setTimeoutSpy).toHaveBeenCalled();
+
+        retryContext.tinyMceRetryCount = 20;
+        setTimeoutSpy.mockClear();
+        BlogPostFormController.prototype.initTinyMceWhenReady.call(
+            retryContext,
+        );
+        expect(setTimeoutSpy).not.toHaveBeenCalled();
+
+        const existingEditorInit = jest.fn();
+        window.tinymce = {
+            get: jest.fn(() => ({ id: "body-editor" })),
+            init: existingEditorInit,
+        };
+        BlogPostFormController.prototype.initTinyMceWhenReady.call({
+            hasEditorTarget: true,
+            editorTarget: { id: "body-editor" },
+            imagesUploadUrlValue: "/admin/images/upload",
+            tinyMceRetryCount: 0,
+            tinyMceRetryTimer: null,
+        });
+        expect(existingEditorInit).not.toHaveBeenCalled();
+
+        window.tinymce = originalTinymce;
+        setTimeoutSpy.mockRestore();
+    });
+
+    test("upload handler covers non-computable progress, missing csrf token, and generic upload failure fallback", async () => {
+        const initConfig = tinymceInitMock.mock.calls[0][0];
+        const blobInfo = {
+            blob: () => new Blob(["img"], { type: "image/jpeg" }),
+            filename: () => "hero.jpg",
+        };
+
+        const csrfMeta = document.querySelector('meta[name="csrfToken"]');
+        csrfMeta?.remove();
+
+        const fallbackXhr = {
+            upload: {},
+            headers: {},
+            open: jest.fn(),
+            setRequestHeader: jest.fn((key, value) => {
+                fallbackXhr.headers[key] = value;
+            }),
+            send: jest.fn(() => {
+                fallbackXhr.upload.onprogress({
+                    lengthComputable: false,
+                    loaded: 1,
+                    total: 10,
+                });
+                fallbackXhr.onload();
+            }),
+            status: 200,
+            responseText: JSON.stringify({ success: false }),
+        };
+
+        window.XMLHttpRequest = jest.fn(() => fallbackXhr);
+        const progress = jest.fn();
+
+        await expect(
+            initConfig.images_upload_handler(blobInfo, progress),
+        ).rejects.toBe("Upload failed");
+        expect(progress).not.toHaveBeenCalled();
+        expect(fallbackXhr.setRequestHeader).not.toHaveBeenCalled();
+    });
+
+    test("destroy, clear hero, update hero, inline guard, and cache bust utility cover fallback branches", async () => {
+        const controller = await getController();
+
+        const originalTinymce = window.tinymce;
+        delete window.tinymce;
+        expect(() => controller.destroyTinyMCE()).not.toThrow();
+
+        window.tinymce = {
+            get: jest.fn(() => null),
+        };
+        controller.destroyTinyMCE();
+        expect(window.tinymce.get).toHaveBeenCalledWith("body-editor");
+        window.tinymce = originalTinymce;
+
+        expect(() =>
+            BlogPostFormController.prototype.clearHeroImage.call({
+                hasHeroFieldTarget: false,
+            }),
+        ).not.toThrow();
+
+        expect(() =>
+            BlogPostFormController.prototype.updateHeroImageState.call({
+                hasHeroFieldTarget: false,
+            }),
+        ).not.toThrow();
+
+        const previewOnly = document.createElement("div");
+        const previewContext = {
+            hasHeroFieldTarget: true,
+            heroFieldTarget: {
+                value: "7",
+                dataset: {
+                    selectedImageUrl: "/img/storage/7.jpg",
+                },
+            },
+            existingHeroIdValue: 12,
+            existingHeroUrlValue: "/img/storage/12-hero.jpg",
+            hasHeroPreviewTarget: true,
+            heroPreviewTarget: previewOnly,
+            hasUnsetHeroButtonTarget: false,
+            hasHeroVariantButtonTarget: false,
+            withCacheBust: jest.fn((url) => url + "?_ts=1"),
+        };
+        BlogPostFormController.prototype.updateHeroImageState.call(
+            previewContext,
+        );
+        expect(previewContext.withCacheBust).not.toHaveBeenCalled();
+        expect(previewOnly.style.display).toBe("block");
+
+        expect(() =>
+            BlogPostFormController.prototype.onInlineFieldChange.call({
+                hasInlineFieldTarget: false,
+            }),
+        ).not.toThrow();
+
+        expect(controller.withCacheBust("")).toBe("");
+        expect(controller.withCacheBust("/img/storage/1.jpg")).toContain(
+            "?_ts=",
+        );
+        expect(
+            controller.withCacheBust("/img/storage/1.jpg?size=hero"),
+        ).toContain("&_ts=");
     });
 });

--- a/js/tests/crop_selector.test.js
+++ b/js/tests/crop_selector.test.js
@@ -1,0 +1,505 @@
+/* global beforeEach, describe, expect, test */
+
+import { jest as jestGlobals } from "@jest/globals";
+
+let CropSelector;
+
+const createContext = () => ({
+    setTransform: jestGlobals.fn(),
+    save: jestGlobals.fn(),
+    translate: jestGlobals.fn(),
+    rotate: jestGlobals.fn(),
+    scale: jestGlobals.fn(),
+    drawImage: jestGlobals.fn(),
+    restore: jestGlobals.fn(),
+    fillRect: jestGlobals.fn(),
+    strokeRect: jestGlobals.fn(),
+    beginPath: jestGlobals.fn(),
+    moveTo: jestGlobals.fn(),
+    lineTo: jestGlobals.fn(),
+    stroke: jestGlobals.fn(),
+    fillStyle: "",
+    strokeStyle: "",
+    lineWidth: 1,
+    imageSmoothingEnabled: false,
+    imageSmoothingQuality: "low",
+});
+
+const setupSelector = ({
+    complete = true,
+    naturalWidth = 200,
+    naturalHeight = 200,
+    clientWidth = 300,
+    imageId = "crop-image",
+    canvasId = "crop-canvas",
+    withContainer = true,
+    options = {},
+} = {}) => {
+    document.body.innerHTML = "";
+
+    const canvas = document.createElement("canvas");
+    canvas.id = canvasId;
+    canvas.width = 200;
+    canvas.height = 200;
+
+    let container = null;
+    if (withContainer) {
+        container = document.createElement("div");
+        Object.defineProperty(container, "clientWidth", {
+            value: clientWidth,
+            configurable: true,
+        });
+        container.appendChild(canvas);
+        document.body.appendChild(container);
+    } else {
+        document.body.appendChild(canvas);
+    }
+
+    const image = document.createElement("img");
+    image.id = imageId;
+    Object.defineProperty(image, "complete", {
+        value: complete,
+        configurable: true,
+    });
+    Object.defineProperty(image, "naturalWidth", {
+        value: naturalWidth,
+        configurable: true,
+    });
+    Object.defineProperty(image, "naturalHeight", {
+        value: naturalHeight,
+        configurable: true,
+    });
+    document.body.appendChild(image);
+
+    const ctx = createContext();
+    canvas.getContext = jestGlobals.fn(() => ctx);
+    canvas.getBoundingClientRect = jestGlobals.fn(() => ({
+        left: 0,
+        top: 0,
+        width: 200,
+        height: 200,
+    }));
+
+    const onCropChange = jestGlobals.fn();
+    const selector = new CropSelector(canvasId, imageId, {
+        ...options,
+        onCropChange,
+    });
+
+    return { selector, canvas, image, ctx, onCropChange, container };
+};
+
+describe("crop_selector js/lib coverage", () => {
+    beforeEach(async () => {
+        jestGlobals.resetModules();
+        document.body.innerHTML = "";
+        try {
+            delete window.devicePixelRatio;
+        } catch {
+            /* ignore */
+        }
+
+        const mod = await import("../lib/crop_selector.js");
+        CropSelector = mod.default || mod;
+    });
+
+    test("constructor throws when required elements are missing", () => {
+        expect(
+            () => new CropSelector("missing-canvas", "missing-image"),
+        ).toThrow("CropSelector: canvas or image element not found");
+    });
+
+    test("initializeCrop returns early when image dimensions are unavailable", () => {
+        const { selector } = setupSelector({
+            naturalWidth: 0,
+            naturalHeight: 0,
+        });
+        const renderSpy = jestGlobals.spyOn(selector, "render");
+
+        selector.initializeCrop();
+
+        expect(renderSpy).not.toHaveBeenCalled();
+        renderSpy.mockRestore();
+    });
+
+    test("initializeCrop emits and applies aspect ratio when configured", () => {
+        const { selector, onCropChange } = setupSelector({
+            options: { aspectRatio: 1 },
+        });
+
+        onCropChange.mockClear();
+        selector.initializeCrop();
+
+        expect(selector.cropBox.width).toBeGreaterThan(0);
+        expect(selector.cropBox.height).toBeGreaterThan(0);
+        expect(
+            Math.abs(selector.cropBox.width - selector.cropBox.height),
+        ).toBeLessThanOrEqual(1);
+        expect(onCropChange).toHaveBeenCalled();
+    });
+
+    test("setAspectRatio handles null and numeric ratios", () => {
+        const { selector } = setupSelector();
+        const snapSpy = jestGlobals.spyOn(selector, "snapToAspectRatio");
+
+        selector.setAspectRatio(null);
+        expect(snapSpy).not.toHaveBeenCalled();
+
+        selector.setAspectRatio(16 / 9);
+        expect(snapSpy).toHaveBeenCalledWith(16 / 9);
+
+        snapSpy.mockRestore();
+    });
+
+    test("snapToAspectRatio clamps when computed height exceeds canvas", () => {
+        const { selector, canvas } = setupSelector();
+        canvas.width = 200;
+        canvas.height = 100;
+
+        selector.snapToAspectRatio(0.1);
+
+        expect(selector.cropBox.height).toBeLessThanOrEqual(100);
+        expect(selector.cropBox.width).toBeLessThanOrEqual(200);
+    });
+
+    test("setCropBox and getCropBox use fallback scale when canvas scale is falsy", () => {
+        const { selector } = setupSelector();
+
+        selector.canvasToImageScale = 0;
+        selector.setCropBox(12, 15, 40, 50);
+
+        expect(selector.cropBox).toEqual({
+            x: 12,
+            y: 15,
+            width: 40,
+            height: 50,
+        });
+        expect(selector.getCropBox()).toEqual({
+            x: 12,
+            y: 15,
+            width: 40,
+            height: 50,
+        });
+    });
+
+    test("setRotation returns early when degrees resolve to same angle", () => {
+        const { selector } = setupSelector();
+        const renderSpy = jestGlobals.spyOn(selector, "render");
+
+        selector.setRotation(0);
+
+        expect(renderSpy).not.toHaveBeenCalled();
+        renderSpy.mockRestore();
+    });
+
+    test("setRotation reprojection branch works with aspect ratio and fallback inverse scale", () => {
+        const { selector } = setupSelector();
+        selector.aspectRatio = 1;
+        selector.canvasToImageScale = 0;
+        selector.cropBox = { x: 5, y: 5, width: 80, height: 40 };
+
+        selector.setRotation(90);
+
+        expect(selector.rotationDeg).toBe(90);
+        expect(selector.cropBox.width).toBeGreaterThan(0);
+        expect(selector.cropBox.height).toBeGreaterThan(0);
+    });
+
+    test("resize handle and inside checks cover hit and miss paths", () => {
+        const { selector } = setupSelector();
+        selector.cropBox = { x: 10, y: 10, width: 100, height: 100 };
+
+        expect(selector.getResizeHandle(10, 10)).toBe("tl");
+        expect(selector.getResizeHandle(0, 0)).toBeNull();
+        expect(selector.isInsideCropBox(20, 20)).toBe(true);
+        expect(selector.isInsideCropBox(190, 190)).toBe(false);
+    });
+
+    test("onMouseDown returns early when image is not ready", () => {
+        const { selector } = setupSelector({ complete: false });
+
+        selector.onMouseDown({
+            clientX: 20,
+            clientY: 20,
+            preventDefault: jestGlobals.fn(),
+        });
+
+        expect(selector.isResizing).toBe(false);
+        expect(selector.isDragging).toBe(false);
+    });
+
+    test("onMouseDown starts resizing for handle and dragging inside crop box", () => {
+        const { selector } = setupSelector();
+        selector.cropBox = { x: 10, y: 10, width: 100, height: 80 };
+
+        const preventResize = jestGlobals.fn();
+        selector.onMouseDown({
+            clientX: 10,
+            clientY: 10,
+            preventDefault: preventResize,
+        });
+        expect(selector.isResizing).toBe(true);
+        expect(selector.resizeHandle).toBe("tl");
+        expect(preventResize).toHaveBeenCalled();
+
+        selector.isResizing = false;
+        selector.resizeHandle = null;
+
+        const preventDrag = jestGlobals.fn();
+        selector.onMouseDown({
+            clientX: 50,
+            clientY: 40,
+            preventDefault: preventDrag,
+        });
+        expect(selector.isDragging).toBe(true);
+        expect(preventDrag).toHaveBeenCalled();
+    });
+
+    test("onMouseDown outside crop box does not start interactions", () => {
+        const { selector } = setupSelector();
+        selector.cropBox = { x: 10, y: 10, width: 80, height: 80 };
+
+        selector.onMouseDown({
+            clientX: 190,
+            clientY: 190,
+            preventDefault: jestGlobals.fn(),
+        });
+
+        expect(selector.isDragging).toBe(false);
+        expect(selector.isResizing).toBe(false);
+    });
+
+    test("onMouseMove updates cursor for unknown handle, inside, and outside", () => {
+        const { selector, canvas } = setupSelector();
+        selector.cropBox = { x: 10, y: 10, width: 100, height: 100 };
+
+        selector.getResizeHandle = jestGlobals.fn(() => "weird");
+        selector.onMouseMove({
+            clientX: 20,
+            clientY: 20,
+            preventDefault: jestGlobals.fn(),
+        });
+        expect(canvas.style.cursor).toBe("move");
+
+        selector.getResizeHandle = jestGlobals.fn(() => null);
+        selector.onMouseMove({
+            clientX: 40,
+            clientY: 40,
+            preventDefault: jestGlobals.fn(),
+        });
+        expect(canvas.style.cursor).toBe("move");
+
+        selector.onMouseMove({
+            clientX: 190,
+            clientY: 190,
+            preventDefault: jestGlobals.fn(),
+        });
+        expect(canvas.style.cursor).toBe("crosshair");
+    });
+
+    test("onMouseMove resizes all handles with and without aspect ratio", () => {
+        const { selector } = setupSelector();
+        const handles = ["tl", "tr", "bl", "br", "t", "b", "l", "r"];
+
+        for (const handle of handles) {
+            selector.cropBox = { x: 20, y: 20, width: 80, height: 60 };
+            selector.isResizing = true;
+            selector.resizeHandle = handle;
+            selector.aspectRatio = 2;
+            selector.onMouseMove({
+                clientX: 140,
+                clientY: 120,
+                preventDefault: jestGlobals.fn(),
+            });
+
+            selector.cropBox = { x: 20, y: 20, width: 80, height: 60 };
+            selector.isResizing = true;
+            selector.resizeHandle = handle;
+            selector.aspectRatio = null;
+            selector.onMouseMove({
+                clientX: 130,
+                clientY: 110,
+                preventDefault: jestGlobals.fn(),
+            });
+        }
+
+        expect(selector.cropBox.width).toBeGreaterThan(0);
+        expect(selector.cropBox.height).toBeGreaterThan(0);
+    });
+
+    test("onMouseMove drag path clamps within bounds for devicePixelRatio values", () => {
+        const { selector } = setupSelector();
+        selector.cropBox = { x: 10, y: 10, width: 70, height: 60 };
+        selector.isDragging = true;
+        selector.dragStartX = 5;
+        selector.dragStartY = 5;
+
+        window.devicePixelRatio = 2;
+        selector.onMouseMove({
+            clientX: 120,
+            clientY: 130,
+            preventDefault: jestGlobals.fn(),
+        });
+
+        window.devicePixelRatio = 0;
+        selector.onMouseMove({
+            clientX: 150,
+            clientY: 160,
+            preventDefault: jestGlobals.fn(),
+        });
+
+        expect(selector.cropBox.x).toBeGreaterThanOrEqual(0);
+        expect(selector.cropBox.y).toBeGreaterThanOrEqual(0);
+    });
+
+    test("onMouseMove returns early when image is not ready", () => {
+        const { selector } = setupSelector({ complete: false });
+
+        selector.onMouseMove({
+            clientX: 20,
+            clientY: 20,
+            preventDefault: jestGlobals.fn(),
+        });
+
+        expect(selector.isDragging).toBe(false);
+        expect(selector.isResizing).toBe(false);
+    });
+
+    test("onMouseUp clears drag and resize state", () => {
+        const { selector } = setupSelector();
+        selector.isDragging = true;
+        selector.isResizing = true;
+        selector.resizeHandle = "br";
+
+        selector.onMouseUp();
+
+        expect(selector.isDragging).toBe(false);
+        expect(selector.isResizing).toBe(false);
+        expect(selector.resizeHandle).toBeNull();
+    });
+
+    test("emitChange handles callback and no-callback branches", () => {
+        const { selector, onCropChange } = setupSelector();
+        selector.emitChange();
+        expect(onCropChange).toHaveBeenCalled();
+
+        const noCallbackSelector = setupSelector({ options: {} }).selector;
+        noCallbackSelector.options = {};
+        expect(() => noCallbackSelector.emitChange()).not.toThrow();
+    });
+
+    test("render returns early when image is incomplete", () => {
+        const { selector, ctx, image } = setupSelector();
+        ctx.drawImage.mockClear();
+        Object.defineProperty(image, "complete", {
+            value: false,
+            configurable: true,
+        });
+
+        selector.render();
+
+        expect(ctx.drawImage).not.toHaveBeenCalled();
+    });
+
+    test("render draws overlays, handles, and fallback width when no container", () => {
+        const { selector, canvas, ctx } = setupSelector({
+            withContainer: false,
+        });
+        selector.cropBox = { x: 10, y: 10, width: 80, height: 80 };
+
+        // Force parentElement null to hit the maxW fallback path.
+        canvas.remove();
+
+        selector.render();
+
+        expect(canvas.width).toBeGreaterThan(0);
+        expect(canvas.height).toBeGreaterThan(0);
+        expect(ctx.drawImage).toHaveBeenCalled();
+        expect(ctx.fillRect).toHaveBeenCalled();
+        expect(ctx.strokeRect).toHaveBeenCalled();
+    });
+
+    test("render rescales crop box when canvasToImageScale changes", () => {
+        const { selector } = setupSelector();
+        selector.canvasToImageScale = 2;
+        selector.cropBox = { x: 12, y: 14, width: 50, height: 40 };
+
+        selector.render();
+
+        expect(selector.cropBox.width).toBeGreaterThan(0);
+        expect(selector.cropBox.height).toBeGreaterThan(0);
+    });
+
+    test("geometry helpers cover clamp and ratio shrink branches", () => {
+        const { selector } = setupSelector();
+
+        const clamped = selector._clampRect(
+            { x: -5, y: -5, width: 30, height: 30 },
+            { x: 0, y: 0, width: 10, height: 12 },
+        );
+        expect(clamped.x).toBe(0);
+        expect(clamped.y).toBe(0);
+
+        const shrunkWide = selector._shrinkToRatio(
+            { x: 90, y: 90, width: 40, height: 10 },
+            1,
+            100,
+            100,
+        );
+        expect(shrunkWide.x + shrunkWide.width).toBeLessThanOrEqual(100);
+        expect(shrunkWide.y + shrunkWide.height).toBeLessThanOrEqual(100);
+
+        const shrunkTall = selector._shrinkToRatio(
+            { x: -10, y: -10, width: 10, height: 40 },
+            1,
+            100,
+            100,
+        );
+        expect(shrunkTall.x).toBeGreaterThanOrEqual(0);
+        expect(shrunkTall.y).toBeGreaterThanOrEqual(0);
+
+        const shrunkPositiveY = selector._shrinkToRatio(
+            { x: 20, y: 20, width: 120, height: 120 },
+            1,
+            80,
+            80,
+        );
+        expect(shrunkPositiveY.y + shrunkPositiveY.height).toBeLessThanOrEqual(
+            80,
+        );
+
+        const shrunkNegativeY = selector._shrinkToRatio(
+            { x: 10, y: -30, width: 60, height: 60 },
+            1,
+            80,
+            80,
+        );
+        expect(shrunkNegativeY.y).toBeGreaterThanOrEqual(0);
+    });
+
+    test("rotation geometry helpers return bounded rectangles", () => {
+        const { selector, image } = setupSelector({
+            naturalWidth: 240,
+            naturalHeight: 120,
+        });
+
+        const original = { x: 20, y: 10, width: 80, height: 40 };
+        const rotated = selector._originalRectToRotatedBBox(
+            original,
+            Math.PI / 4,
+            image.naturalWidth,
+            image.naturalHeight,
+        );
+        const restored = selector._rotatedRectToOriginalBBox(
+            rotated,
+            Math.PI / 4,
+            image.naturalWidth,
+            image.naturalHeight,
+        );
+
+        expect(rotated.width).toBeGreaterThan(0);
+        expect(rotated.height).toBeGreaterThan(0);
+        expect(restored.x).toBeGreaterThanOrEqual(0);
+        expect(restored.y).toBeGreaterThanOrEqual(0);
+    });
+});

--- a/js/tests/field_mapping_controller.test.js
+++ b/js/tests/field_mapping_controller.test.js
@@ -1,0 +1,64 @@
+/* global afterEach, beforeEach, describe, expect, jest, test */
+
+import { Application } from "@hotwired/stimulus";
+
+import FieldMappingController from "../controllers/field_mapping_controller.js";
+
+describe("field-mapping controller", () => {
+    let application;
+
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div data-controller="field-mapping">
+                <div id="field-mapping-container" data-field-mapping-target="container">
+                    <div class="field-mapping-row">
+                        <input name="rows[0][source]" value="first" />
+                        <select name="rows[0][type]"><option value="a" selected>A</option></select>
+                        <button type="button" class="remove-field">Remove</button>
+                    </div>
+                </div>
+                <button id="add-field" type="button" data-field-mapping-target="addButton">Add</button>
+            </div>
+        `;
+
+        application = Application.start();
+        application.register("field-mapping", FieldMappingController);
+    });
+
+    afterEach(() => {
+        if (application) {
+            application.stop();
+            application = null;
+        }
+
+        document.body.innerHTML = "";
+        jest.restoreAllMocks();
+    });
+
+    test("disables remove buttons until more than one row exists", () => {
+        expect(document.querySelector(".remove-field").disabled).toBe(true);
+    });
+
+    test("adds a row and enables removal", () => {
+        document.getElementById("add-field").click();
+
+        expect(document.querySelectorAll(".field-mapping-row")).toHaveLength(2);
+        expect(document.querySelectorAll(".remove-field")[0].disabled).toBe(
+            false,
+        );
+        expect(document.querySelectorAll(".remove-field")[1].disabled).toBe(
+            false,
+        );
+    });
+
+    test("removes a row when the remove button is clicked", () => {
+        const row = document.querySelector(".field-mapping-row");
+        const removeButton = row.querySelector(".remove-field");
+
+        document.getElementById("add-field").click();
+        removeButton.click();
+
+        expect(document.querySelectorAll(".field-mapping-row")).toHaveLength(1);
+        expect(document.querySelector(".remove-field").disabled).toBe(true);
+    });
+});

--- a/js/tests/image_selector_controller.test.js
+++ b/js/tests/image_selector_controller.test.js
@@ -1,0 +1,584 @@
+/* global Blob, File, MouseEvent, afterEach, beforeEach, describe, expect, jest, test */
+
+import { Application } from "@hotwired/stimulus";
+
+import ImageSelectorController from "../controllers/image_selector_controller.js";
+
+const flush = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+};
+
+const getController = (application) =>
+    application.controllers.find(
+        (controller) => controller.identifier === "image-selector",
+    );
+
+describe("image-selector controller", () => {
+    let application;
+    let hideMock;
+
+    beforeEach(() => {
+        hideMock = jest.fn();
+
+        document.body.innerHTML = `
+            <meta name="csrfToken" content="csrf-token" />
+            <div id="image-modal" data-controller="image-selector" class="modal fade">
+                <button id="image-modal-select-tab" type="button">Select</button>
+                <button id="image-modal-upload-tab" type="button">Upload</button>
+                <input id="image-modal-search" type="text" />
+                <div id="image-modal-gallery" class="row"></div>
+                <input id="image-modal-file-input" type="file" />
+                <div id="image-modal-crop-container" style="display:none;">
+                    <img id="image-modal-crop-image" alt="crop" />
+                    <div id="image-modal-crop-preview" style="display:none;"></div>
+                </div>
+                <div id="image-modal-no-preview" style="display:block;">No preview</div>
+                <div id="image-modal-crop-controls" style="display:none;"></div>
+                <form id="image-modal-tag-form">
+                    <input name="tags" value="featured" />
+                </form>
+                <input id="image-modal-skip-crop" type="checkbox" />
+                <button id="image-modal-select-btn" type="button">Select image</button>
+                <button id="image-modal-upload-btn" type="button">Upload &amp; Crop</button>
+                <button id="image-modal-rotate-left" type="button">Rotate left</button>
+                <button id="image-modal-rotate-right" type="button">Rotate right</button>
+                <button id="image-modal-reset-crop" type="button">Reset crop</button>
+            </div>
+            <input id="image-target" value="2" />
+        `;
+
+        window.imageSelectorConfig = {
+            "image-modal": {
+                targetFieldId: "image-target",
+                aspectRatio: 1.5,
+                tagFilter: "featured",
+                uploadContext: { entity: "person" },
+            },
+        };
+
+        window.bootstrap = {
+            Modal: {
+                getInstance: jest.fn(() => ({ hide: hideMock })),
+            },
+        };
+
+        window.Cropper = jest.fn(() => ({
+            destroy: jest.fn(),
+            rotate: jest.fn(),
+            reset: jest.fn(),
+            getCroppedCanvas: jest.fn(() => ({
+                toBlob: jest.fn((callback) =>
+                    callback(new Blob(["cropped"], { type: "image/jpeg" })),
+                ),
+            })),
+        }));
+
+        window.FileReader = class FileReaderMock {
+            readAsDataURL() {
+                if (typeof this.onload === "function") {
+                    this.onload({
+                        target: { result: "data:image/jpeg;base64,abc" },
+                    });
+                }
+            }
+        };
+
+        globalThis.fetch = jest.fn();
+
+        application = Application.start();
+        application.register("image-selector", ImageSelectorController);
+    });
+
+    afterEach(() => {
+        if (application) {
+            application.stop();
+            application = null;
+        }
+
+        delete window.imageSelectorConfig;
+        delete window.bootstrap;
+        delete window.Cropper;
+        delete window.FileReader;
+        delete globalThis.fetch;
+        document.body.innerHTML = "";
+        jest.restoreAllMocks();
+        jest.resetModules();
+    });
+
+    test("loads images, filters gallery, selects an image, and resets on modal hide", async () => {
+        fetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                images: [
+                    {
+                        id: 1,
+                        url: "/img/1.jpg",
+                        thumbnail_url: "/img/1-thumb.jpg",
+                        original_name: "first.jpg",
+                        tags: ["featured", "hero"],
+                    },
+                    {
+                        id: 2,
+                        url: "/img/2.jpg",
+                        thumbnail_url: "/img/2-thumb.jpg",
+                        original_name: "second.jpg",
+                        tags: ["archive"],
+                    },
+                ],
+            }),
+        });
+
+        const modal = document.getElementById("image-modal");
+        const target = document.getElementById("image-target");
+
+        modal.dispatchEvent(new Event("shown.bs.modal"));
+        await flush();
+
+        expect(fetch).toHaveBeenCalledWith(
+            "/admin/images/browse?tag=featured",
+            {
+                credentials: "same-origin",
+            },
+        );
+        expect(target.dataset.selectedImageUrl).toBe("/img/2.jpg");
+
+        const searchInput = document.getElementById("image-modal-search");
+        searchInput.value = "first";
+        searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+
+        expect(
+            document.getElementById("image-modal-gallery").innerHTML,
+        ).toContain("#1");
+        expect(
+            document.getElementById("image-modal-gallery").innerHTML,
+        ).not.toContain("#2");
+
+        document
+            .querySelector('[data-image-id="1"]')
+            .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        document.getElementById("image-modal-select-btn").click();
+
+        expect(target.value).toBe("1");
+        expect(target.dataset.selectedImageThumbnailUrl).toBe(
+            "/img/1-thumb.jpg",
+        );
+        expect(hideMock).toHaveBeenCalledTimes(1);
+
+        document.querySelector('[data-image-id="1"]').classList.add("border");
+        document.getElementById("image-modal-skip-crop").checked = true;
+        modal.dispatchEvent(new Event("hidden.bs.modal"));
+
+        expect(
+            document.getElementById("image-modal-crop-container").style.display,
+        ).toBe("none");
+        expect(
+            document.getElementById("image-modal-no-preview").style.display,
+        ).toBe("block");
+        expect(
+            document
+                .querySelector('[data-image-id="1"]')
+                .classList.contains("border"),
+        ).toBe(false);
+    });
+
+    test("handles file selection, cropper controls, and upload with crop context", async () => {
+        fetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                success: true,
+                image: {
+                    id: 77,
+                    url: "/img/77.jpg",
+                    thumbnail_url: "/img/77-thumb.jpg",
+                    hero_url: "/img/77-hero.jpg",
+                },
+            }),
+        });
+
+        const fileInput = document.getElementById("image-modal-file-input");
+        const file = new File(["abc"], "photo.jpg", { type: "image/jpeg" });
+
+        Object.defineProperty(fileInput, "files", {
+            configurable: true,
+            value: [file],
+        });
+
+        fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+        await flush();
+
+        expect(window.Cropper).toHaveBeenCalledTimes(1);
+        expect(
+            document.getElementById("image-modal-crop-container").style.display,
+        ).toBe("block");
+        expect(
+            document.getElementById("image-modal-crop-preview").style.display,
+        ).toBe("block");
+
+        const cropperInstance = window.Cropper.mock.results[0].value;
+        document.getElementById("image-modal-rotate-left").click();
+        document.getElementById("image-modal-rotate-right").click();
+        document.getElementById("image-modal-reset-crop").click();
+
+        expect(cropperInstance.rotate).toHaveBeenCalledWith(-90);
+        expect(cropperInstance.rotate).toHaveBeenCalledWith(90);
+        expect(cropperInstance.reset).toHaveBeenCalledTimes(1);
+
+        document.getElementById("image-modal-upload-btn").click();
+        await flush();
+        await flush();
+
+        expect(fetch).toHaveBeenCalledWith(
+            "/admin/images/upload",
+            expect.objectContaining({
+                method: "POST",
+                credentials: "same-origin",
+            }),
+        );
+
+        const uploadCall = fetch.mock.calls.at(-1);
+        expect(uploadCall[1].headers["X-CSRF-Token"]).toBe("csrf-token");
+        expect(uploadCall[1].body.get("upload")).toBeInstanceOf(Blob);
+        expect(uploadCall[1].body.get("tags")).toBe("featured");
+        expect(uploadCall[1].body.get("context")).toBe(
+            JSON.stringify({ entity: "person" }),
+        );
+        expect(document.getElementById("image-target").value).toBe("77");
+        expect(hideMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("handles guard and failure paths for loading, selecting, and uploading", async () => {
+        const alertSpy = jest
+            .spyOn(window, "alert")
+            .mockImplementation(() => {});
+        const errorSpy = jest
+            .spyOn(console, "error")
+            .mockImplementation(() => {});
+
+        document.getElementById("image-modal-select-btn").click();
+        expect(alertSpy).toHaveBeenCalledWith("Please select an image");
+
+        document.getElementById("image-modal-upload-btn").click();
+        expect(alertSpy).toHaveBeenCalledWith("Please select an image first");
+
+        fetch
+            .mockResolvedValueOnce({ ok: false, json: async () => ({}) })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ success: false, error: "bad upload" }),
+            });
+
+        document
+            .getElementById("image-modal")
+            .dispatchEvent(new Event("shown.bs.modal"));
+        await flush();
+        expect(
+            document.getElementById("image-modal-gallery").innerHTML,
+        ).toContain("Failed to load images");
+
+        delete window.Cropper;
+        const fileInput = document.getElementById("image-modal-file-input");
+        const file = new File(["abc"], "photo.jpg", { type: "image/jpeg" });
+        Object.defineProperty(fileInput, "files", {
+            configurable: true,
+            value: [file],
+        });
+        fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+        await flush();
+
+        expect(errorSpy).toHaveBeenCalledWith("Cropper.js is not available.");
+
+        document.getElementById("image-modal-skip-crop").checked = true;
+        document.getElementById("image-modal-upload-btn").click();
+        await flush();
+        await flush();
+
+        expect(alertSpy).toHaveBeenCalledWith("Upload failed: bad upload");
+
+        alertSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
+
+    test("covers guard branches for missing elements and no-file selection", async () => {
+        const controller = getController(application);
+        expect(controller).toBeTruthy();
+
+        controller.selectBtn = null;
+        controller.uploadBtn = null;
+        expect(() => controller.toggleActionButtons(true)).not.toThrow();
+
+        controller.gallery = null;
+        await controller.loadImages();
+        expect(fetch).not.toHaveBeenCalled();
+
+        const fileInput = document.getElementById("image-modal-file-input");
+        Object.defineProperty(fileInput, "files", {
+            configurable: true,
+            value: [],
+        });
+        fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+
+        expect(controller.selectedFile).toBeNull();
+    });
+
+    test("covers empty gallery and unmatched selection behavior", () => {
+        const controller = getController(application);
+        const gallery = document.getElementById("image-modal-gallery");
+
+        controller.renderGallery([]);
+        expect(gallery.innerHTML).toContain("No images found");
+
+        controller.loadedImages = [
+            {
+                id: 10,
+                url: "/img/10.jpg",
+                original_name: "ten.jpg",
+            },
+        ];
+
+        const unmatchedCard = document.createElement("div");
+        unmatchedCard.className = "card image-card";
+        unmatchedCard.dataset.imageId = "99";
+        gallery.appendChild(unmatchedCard);
+
+        controller.onGalleryImageClick(unmatchedCard);
+
+        expect(controller.selectedImageId).toBe(99);
+        expect(controller.selectedImage).toBeNull();
+
+        controller.onSearch("zzz");
+        expect(gallery.innerHTML).toContain("No images found");
+    });
+
+    test("covers selection sync and data-clearing branches", () => {
+        const controller = getController(application);
+        const target = document.getElementById("image-target");
+
+        target.value = "abc";
+        target.dataset.selectedImageUrl = "/img/old.jpg";
+        target.dataset.selectedImageThumbnailUrl = "/img/old-thumb.jpg";
+        target.dataset.selectedImageHeroUrl = "/img/old-hero.jpg";
+
+        controller.loadedImages = [
+            {
+                id: 2,
+                url: "/img/2.jpg",
+                thumbnail_url: "/img/2-thumb.jpg",
+            },
+        ];
+
+        controller.syncTargetFieldSelection();
+        expect(target.dataset.selectedImageUrl).toBe("/img/old.jpg");
+
+        controller.applySelectedImageData(null);
+        expect(target.dataset.selectedImageUrl).toBeUndefined();
+        expect(target.dataset.selectedImageThumbnailUrl).toBeUndefined();
+        expect(target.dataset.selectedImageHeroUrl).toBeUndefined();
+
+        controller.applySelectedImageData({ id: 2, url: "/img/2.jpg" });
+        expect(target.dataset.selectedImageUrl).toBe("/img/2.jpg");
+        expect(target.dataset.selectedImageThumbnailUrl).toBeUndefined();
+        expect(target.dataset.selectedImageHeroUrl).toBeUndefined();
+    });
+
+    test("covers upload fallback and preparation error branches", async () => {
+        const controller = getController(application);
+        const alertSpy = jest
+            .spyOn(window, "alert")
+            .mockImplementation(() => {});
+
+        controller.selectedFile = new File(["abc"], "photo.jpg", {
+            type: "image/jpeg",
+        });
+
+        controller.uploadBtn = null;
+        await controller.onUploadImage();
+
+        controller.uploadBtn = document.getElementById(
+            "image-modal-upload-btn",
+        );
+        controller.tagForm = null;
+        controller.targetField = null;
+        controller.config.uploadContext = null;
+        controller.skipCropToggle.checked = false;
+
+        const csrfMeta = document.querySelector('meta[name="csrfToken"]');
+        csrfMeta.remove();
+
+        controller.cropper = {
+            getCroppedCanvas: () => ({
+                toBlob: (callback) => callback(null),
+            }),
+        };
+
+        await controller.onUploadImage();
+
+        expect(fetch).not.toHaveBeenCalled();
+        expect(alertSpy).toHaveBeenCalledWith(
+            "Upload failed: Unable to prepare image",
+        );
+        expect(controller.uploadBtn.disabled).toBe(false);
+        expect(controller.uploadBtn.textContent).toBe("Upload & Crop");
+
+        alertSpy.mockRestore();
+    });
+
+    test("covers connect defaults, gallery click miss, and unbind/destroy guards", async () => {
+        application.stop();
+        delete window.imageSelectorConfig["image-modal"];
+
+        application = Application.start();
+        application.register("image-selector", ImageSelectorController);
+
+        await flush();
+
+        const controller = getController(application);
+        const gallery = document.getElementById("image-modal-gallery");
+
+        expect(controller.config).toEqual({});
+        expect(controller.aspectRatio).toBeNull();
+
+        gallery.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        expect(controller.selectedImageId).toBeNull();
+
+        controller.listeners = null;
+        expect(() => controller.unbindEvents()).not.toThrow();
+
+        const destroy = jest.fn();
+        controller.cropper = { destroy };
+        controller.destroyCropper();
+        expect(destroy).toHaveBeenCalled();
+        expect(controller.cropper).toBeNull();
+    });
+
+    test("covers modal-hidden optional paths and select-tab no-reload branch", () => {
+        const controller = getController(application);
+
+        controller.fileInput = null;
+        controller.skipCropToggle = null;
+        controller.cropContainer = null;
+        controller.cropPreview = null;
+        controller.noPreview = null;
+        controller.cropControls = null;
+        controller.onModalHidden();
+
+        const loadSpy = jest
+            .spyOn(controller, "loadImages")
+            .mockImplementation(() => Promise.resolve());
+        controller.loadedImages = [{ id: 1, url: "/img/1.jpg" }];
+        controller.onSelectTabShown();
+        expect(loadSpy).not.toHaveBeenCalled();
+        loadSpy.mockRestore();
+
+        controller.toggleActionButtons(false);
+        expect(controller.selectBtn.style.display).toBe("none");
+        expect(controller.uploadBtn.style.display).toBe("inline-block");
+
+        const hideSpy = jest.spyOn(window.bootstrap.Modal, "getInstance");
+        controller.targetField = null;
+        controller.selectedImageId = 11;
+        controller.selectedImage = { id: 11, url: "/img/11.jpg" };
+        controller.onSelectImage();
+        expect(hideSpy).toHaveBeenCalled();
+        hideSpy.mockRestore();
+    });
+
+    test("covers loadImages tag-filter query and sync fallback to null selection", async () => {
+        const controller = getController(application);
+        const target = document.getElementById("image-target");
+
+        controller.config.tagFilter = "portrait";
+        target.value = "999";
+        target.dataset.selectedImageUrl = "/img/old.jpg";
+
+        fetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({}),
+        });
+
+        await controller.loadImages();
+
+        expect(fetch).toHaveBeenCalledWith(
+            expect.stringContaining("tag=portrait"),
+            expect.objectContaining({ credentials: "same-origin" }),
+        );
+        expect(controller.loadedImages).toEqual([]);
+        expect(target.dataset.selectedImageUrl).toBeUndefined();
+        expect(controller.gallery.innerHTML).toContain("No images found");
+    });
+
+    test("covers file-selected optional element guards and missing Cropper", async () => {
+        const controller = getController(application);
+        const fileInput = document.getElementById("image-modal-file-input");
+        const errorSpy = jest
+            .spyOn(console, "error")
+            .mockImplementation(() => {});
+        const previousCropper = window.Cropper;
+
+        controller.skipCropToggle = null;
+        controller.cropImage = null;
+        controller.cropContainer = null;
+        controller.cropPreview = null;
+        controller.noPreview = null;
+        controller.cropControls = null;
+        window.Cropper = undefined;
+
+        Object.defineProperty(fileInput, "files", {
+            configurable: true,
+            value: [
+                new File(["file"], "no-cropper.jpg", {
+                    type: "image/jpeg",
+                }),
+            ],
+        });
+
+        fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+        await flush();
+
+        expect(errorSpy).toHaveBeenCalledWith("Cropper.js is not available.");
+
+        window.Cropper = previousCropper;
+        errorSpy.mockRestore();
+    });
+
+    test("covers upload not-ok response and API error fallback branches", async () => {
+        const controller = getController(application);
+        const alertSpy = jest
+            .spyOn(window, "alert")
+            .mockImplementation(() => {});
+
+        controller.selectedFile = new File(["img"], "", {
+            type: "image/jpeg",
+        });
+        controller.skipCropToggle.checked = false;
+        controller.aspectRatio = null;
+        controller.targetField = null;
+        controller.cropper = {
+            getCroppedCanvas: jest.fn(() => ({
+                toBlob: (callback) =>
+                    callback(new Blob(["jpeg"], { type: "image/jpeg" })),
+            })),
+        };
+
+        fetch.mockResolvedValueOnce({
+            ok: false,
+            json: async () => ({}),
+        });
+        await controller.onUploadImage();
+
+        fetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ success: false }),
+        });
+        await controller.onUploadImage();
+
+        expect(alertSpy).toHaveBeenCalledWith("Upload failed: Upload failed");
+        expect(controller.cropper.getCroppedCanvas).toHaveBeenCalledWith(
+            undefined,
+        );
+        expect(controller.uploadBtn.disabled).toBe(false);
+        expect(controller.uploadBtn.textContent).toBe("Upload & Crop");
+
+        alertSpy.mockRestore();
+    });
+});

--- a/js/tests/image_upload_controller.test.js
+++ b/js/tests/image_upload_controller.test.js
@@ -4,30 +4,72 @@ import { Application } from "@hotwired/stimulus";
 
 import ImageUploadController from "../controllers/image_upload_controller.js";
 
+const flushPromises = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+};
+
 describe("image-upload controller", () => {
     let application;
 
-    beforeEach(() => {
+    const getController = async () => {
+        const root = document.querySelector('[data-controller="image-upload"]');
+
+        for (let i = 0; i < 4; i += 1) {
+            const controller =
+                application.getControllerForElementAndIdentifier(
+                    root,
+                    "image-upload",
+                ) ||
+                application.controllers.find(
+                    (item) => item.identifier === "image-upload",
+                );
+
+            if (controller) {
+                return controller;
+            }
+
+            await Promise.resolve();
+        }
+
+        return undefined;
+    };
+
+    function renderFixture({
+        includeFileInput = true,
+        includeBrightness = true,
+        includeContrast = true,
+        includeRotate = true,
+        includeForm = true,
+        includePreview = true,
+        includeStatus = true,
+        includeTags = true,
+        includeFileInputChangeAction = true,
+        includeRotationAction = true,
+    } = {}) {
         document.body.innerHTML = `
             <div data-controller="image-upload">
-                <form id="uploadForm" action="/admin/images/upload" data-image-upload-target="form">
-                    <input id="imageFile" type="file" data-image-upload-target="fileInput" />
-                    <input id="tags" data-image-upload-target="tags" />
-                    <input id="brightness" type="range" value="0" data-image-upload-target="brightness" />
+                ${includeForm ? '<form id="uploadForm" action="/admin/images/upload" data-image-upload-target="form">' : '<div id="uploadForm">'}
+                    ${includeFileInput ? `<input id="imageFile" type="file" data-image-upload-target="fileInput" ${includeFileInputChangeAction ? 'data-action="change->image-upload#handleFileChange"' : ""} />` : ""}
+                    ${includeTags ? '<input id="tags" data-image-upload-target="tags" />' : ""}
+                    ${includeBrightness ? '<input id="brightness" type="range" value="0" data-image-upload-target="brightness" />' : ""}
                     <span id="brightnessBadge" data-image-upload-target="brightnessBadge">0</span>
-                    <input id="contrast" type="range" value="0" data-image-upload-target="contrast" />
+                    ${includeContrast ? '<input id="contrast" type="range" value="0" data-image-upload-target="contrast" />' : ""}
                     <span id="contrastBadge" data-image-upload-target="contrastBadge">0</span>
-                    <input id="rotate" type="hidden" value="0" data-image-upload-target="rotate" />
+                    ${includeRotate ? `<input id="rotate" type="hidden" value="0" data-image-upload-target="rotate" />` : ""}
+                    ${includeRotate && includeRotationAction ? '<button id="rotateButton" type="button" data-action="click->image-upload#setRotation" data-image-upload-degrees-param="180"></button>' : ""}
                     <button type="submit"><span id="uploadBtn" data-image-upload-target="submitLabel">Upload Image</span><span id="uploadSpinner" class="d-none" data-image-upload-target="submitSpinner"></span></button>
-                </form>
-                <div id="previewContainer" class="d-none" data-image-upload-target="previewContainer">
-                    <img id="previewImage" data-image-upload-target="previewImage" alt="Preview" />
-                </div>
-                <div id="manipulationControls" class="d-none" data-image-upload-target="manipulationControls"></div>
-                <p id="noFileText" data-image-upload-target="noFileText">Select an image above to see adjustment options</p>
-                <div id="uploadStatus" class="d-none" data-image-upload-target="status"></div>
+                ${includeForm ? "</form>" : "</div>"}
+                ${includePreview ? '<div id="previewContainer" class="d-none" data-image-upload-target="previewContainer"><img id="previewImage" data-image-upload-target="previewImage" alt="Preview" /></div>' : ""}
+                ${includePreview ? '<div id="manipulationControls" class="d-none" data-image-upload-target="manipulationControls"></div>' : ""}
+                ${includePreview ? '<p id="noFileText" data-image-upload-target="noFileText">Select an image above to see adjustment options</p>' : ""}
+                ${includeStatus ? '<div id="uploadStatus" class="d-none" data-image-upload-target="status"></div>' : ""}
             </div>
         `;
+    }
+
+    beforeEach(() => {
+        renderFixture();
 
         window.FileReader = class FileReaderMock {
             readAsDataURL() {
@@ -67,6 +109,7 @@ describe("image-upload controller", () => {
         const fileInput = document.getElementById("imageFile");
         const brightness = document.getElementById("brightness");
         const contrast = document.getElementById("contrast");
+        const rotate = document.getElementById("rotate");
 
         const file = new window.File(["abc"], "photo.png", {
             type: "image/png",
@@ -81,6 +124,7 @@ describe("image-upload controller", () => {
         brightness.dispatchEvent(new Event("input", { bubbles: true }));
         contrast.value = "15";
         contrast.dispatchEvent(new Event("input", { bubbles: true }));
+        document.getElementById("rotateButton").click();
 
         expect(
             document
@@ -102,6 +146,127 @@ describe("image-upload controller", () => {
             "25",
         );
         expect(document.getElementById("contrastBadge").textContent).toBe("15");
+        expect(rotate.value).toBe("180");
+    });
+
+    test("resets preview state when no file is selected", () => {
+        const fileInput = document.getElementById("imageFile");
+        const previewImage = document.getElementById("previewImage");
+
+        previewImage.setAttribute("src", "data:image/png;base64,abc");
+        Object.defineProperty(fileInput, "files", {
+            value: [],
+            configurable: true,
+        });
+
+        fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+
+        expect(previewImage.getAttribute("src")).toBeNull();
+        expect(
+            document.getElementById("noFileText").classList.contains("d-none"),
+        ).toBe(false);
+        expect(
+            document
+                .getElementById("previewContainer")
+                .classList.contains("d-none"),
+        ).toBe(true);
+    });
+
+    test("shows an error when submitting without a selected file", () => {
+        const form = document.getElementById("uploadForm");
+
+        form.dispatchEvent(
+            new Event("submit", { bubbles: true, cancelable: true }),
+        );
+
+        expect(globalThis.fetch).not.toHaveBeenCalled();
+        expect(document.getElementById("uploadStatus").textContent).toContain(
+            "Please select an image file",
+        );
+    });
+
+    test("submits only non-empty optional fields and handles failed responses", async () => {
+        const fileInput = document.getElementById("imageFile");
+        const tags = document.getElementById("tags");
+        const form = document.getElementById("uploadForm");
+        const rotate = document.getElementById("rotate");
+        const brightness = document.getElementById("brightness");
+        const contrast = document.getElementById("contrast");
+
+        const file = new window.File(["abc"], "photo.png", {
+            type: "image/png",
+        });
+        Object.defineProperty(fileInput, "files", {
+            value: [file],
+            configurable: true,
+        });
+
+        fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+        tags.value = "   ";
+        rotate.value = "-90";
+        brightness.value = "0";
+        contrast.value = "0";
+
+        globalThis.fetch.mockResolvedValueOnce({
+            json: async () => ({ success: false, error: "bad upload" }),
+        });
+
+        form.dispatchEvent(
+            new Event("submit", { bubbles: true, cancelable: true }),
+        );
+
+        await flushPromises();
+
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+        const [, options] = globalThis.fetch.mock.calls[0];
+        expect(options.body.get("tags")).toBeNull();
+        expect(options.body.get("rotate")).toBeNull();
+        expect(options.body.get("brightness")).toBeNull();
+        expect(options.body.get("contrast")).toBeNull();
+        expect(document.getElementById("uploadStatus").textContent).toContain(
+            "bad upload",
+        );
+    });
+
+    test("shows upload errors and tolerates missing optional targets", async () => {
+        application.stop();
+        application = null;
+
+        renderFixture({
+            includeFileInput: false,
+            includeBrightness: false,
+            includeContrast: false,
+            includeRotate: false,
+            includeForm: false,
+            includePreview: false,
+            includeStatus: false,
+            includeTags: false,
+        });
+
+        application = Application.start();
+        application.register("image-upload", ImageUploadController);
+
+        expect(document.getElementById("brightnessBadge").textContent).toBe(
+            "0",
+        );
+        expect(document.getElementById("contrastBadge").textContent).toBe("0");
+
+        const errorSpy = jest
+            .spyOn(globalThis, "fetch")
+            .mockRejectedValueOnce(new Error("network failed"));
+        errorSpy.mockRejectedValueOnce(new Error("network failed again"));
+
+        expect(() =>
+            document
+                .querySelector('[data-controller="image-upload"]')
+                .dispatchEvent(
+                    new Event("submit", { bubbles: true, cancelable: true }),
+                ),
+        ).not.toThrow();
+
+        await flushPromises();
+
+        expect(errorSpy).not.toHaveBeenCalled();
     });
 
     test("submits upload data and redirects on success", async () => {
@@ -145,5 +310,230 @@ describe("image-upload controller", () => {
         expect(document.getElementById("uploadStatus").textContent).toContain(
             "Image uploaded successfully",
         );
+    });
+
+    test("disconnect and no-target guards are safe", async () => {
+        application.stop();
+        application = null;
+
+        renderFixture({
+            includeFileInput: false,
+            includeBrightness: false,
+            includeContrast: false,
+            includeRotate: false,
+            includeForm: false,
+            includePreview: false,
+            includeStatus: false,
+            includeTags: false,
+        });
+
+        application = Application.start();
+        application.register("image-upload", ImageUploadController);
+        const controller = await getController();
+
+        expect(() => controller.disconnect()).not.toThrow();
+    });
+
+    test("handleFileChange handles preview guard and reader result fallback", () => {
+        const originalFileReader = window.FileReader;
+        window.FileReader = class FileReaderFallbackMock {
+            readAsDataURL() {
+                if (typeof this.onload === "function") {
+                    this.onload({ target: undefined });
+                }
+            }
+        };
+
+        const withPreviewContext = {
+            hasPreviewImageTarget: true,
+            previewImageTarget: { src: "initial" },
+            showPreviewState: jest.fn(),
+            currentImageFile: null,
+        };
+        const file = new window.File(["abc"], "photo.png", {
+            type: "image/png",
+        });
+
+        ImageUploadController.prototype.handleFileChange.call(
+            withPreviewContext,
+            {
+                target: { files: [file] },
+            },
+        );
+
+        expect(withPreviewContext.previewImageTarget.src).toBe("");
+        expect(withPreviewContext.showPreviewState).toHaveBeenCalledTimes(1);
+
+        const noPreviewContext = {
+            hasPreviewImageTarget: false,
+            showPreviewState: jest.fn(),
+            currentImageFile: null,
+        };
+
+        ImageUploadController.prototype.handleFileChange.call(
+            noPreviewContext,
+            {
+                target: { files: [file] },
+            },
+        );
+        expect(noPreviewContext.showPreviewState).toHaveBeenCalledTimes(1);
+
+        window.FileReader = originalFileReader;
+    });
+
+    test("brightness, contrast, and rotation branches handle fallbacks", async () => {
+        const controller = await getController();
+
+        controller.handleBrightnessInput({
+            currentTarget: { value: "7" },
+        });
+        expect(document.getElementById("brightnessBadge").textContent).toBe(
+            "7",
+        );
+
+        controller.handleBrightnessInput({});
+        expect(document.getElementById("brightnessBadge").textContent).toBe(
+            "0",
+        );
+
+        controller.handleContrastInput({
+            currentTarget: { value: "-3" },
+        });
+        expect(document.getElementById("contrastBadge").textContent).toBe("-3");
+
+        controller.handleContrastInput({});
+        expect(document.getElementById("contrastBadge").textContent).toBe("0");
+
+        controller.setRotation({ params: { degrees: 270 } });
+        expect(document.getElementById("rotate").value).toBe("270");
+
+        controller.setRotation({});
+        expect(document.getElementById("rotate").value).toBe("0");
+
+        expect(() =>
+            ImageUploadController.prototype.setRotation.call(
+                { hasRotateTarget: false },
+                { params: { degrees: 180 } },
+            ),
+        ).not.toThrow();
+    });
+
+    test("submit uses upload fallback URL, omits optional fields, and handles generic failure message", async () => {
+        application.stop();
+        application = null;
+
+        renderFixture({
+            includeTags: false,
+            includeRotate: false,
+            includeBrightness: false,
+            includeContrast: false,
+        });
+
+        application = Application.start();
+        application.register("image-upload", ImageUploadController);
+        const controller = await getController();
+
+        const file = new window.File(["abc"], "photo.png", {
+            type: "image/png",
+        });
+        controller.currentImageFile = file;
+
+        const form = document.getElementById("uploadForm");
+        form.removeAttribute("action");
+
+        globalThis.fetch.mockResolvedValueOnce({
+            json: async () => ({ success: false }),
+        });
+
+        await controller.submit({ preventDefault: jest.fn() });
+
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+        const [url, options] = globalThis.fetch.mock.calls[0];
+        expect(url).toBe("/admin/images/upload");
+        expect(options.body.get("tags")).toBeNull();
+        expect(options.body.get("rotate")).toBeNull();
+        expect(options.body.get("brightness")).toBeNull();
+        expect(options.body.get("contrast")).toBeNull();
+        expect(document.getElementById("uploadStatus").textContent).toContain(
+            "Upload failed",
+        );
+    });
+
+    test("submit catch branch and helper guard branches are covered", async () => {
+        application.stop();
+        application = null;
+
+        renderFixture({
+            includeForm: false,
+            includeStatus: true,
+        });
+
+        application = Application.start();
+        application.register("image-upload", ImageUploadController);
+        const controller = await getController();
+
+        const file = new window.File(["abc"], "photo.png", {
+            type: "image/png",
+        });
+        controller.currentImageFile = file;
+
+        globalThis.fetch.mockRejectedValueOnce(new Error("network down"));
+        await controller.submit({ preventDefault: jest.fn() });
+
+        expect(document.getElementById("uploadStatus").textContent).toContain(
+            "Upload error: network down",
+        );
+
+        expect(() => controller.updateAdjustmentBadge(null, 10)).not.toThrow();
+
+        const badge = document.createElement("span");
+        controller.updateAdjustmentBadge(badge, -9);
+        expect(badge.className).toContain("bg-danger");
+
+        expect(() =>
+            ImageUploadController.prototype.togglePreviewSections.call(
+                {
+                    hasPreviewContainerTarget: false,
+                    hasManipulationControlsTarget: false,
+                    hasNoFileTextTarget: false,
+                },
+                true,
+            ),
+        ).not.toThrow();
+
+        expect(() =>
+            ImageUploadController.prototype.showStatus.call(
+                { hasStatusTarget: false },
+                "error",
+                "ignored",
+            ),
+        ).not.toThrow();
+
+        const submitGuardContext = {
+            hasSubmitLabelTarget: false,
+            hasSubmitSpinnerTarget: false,
+            hasFormTarget: false,
+        };
+        expect(() =>
+            ImageUploadController.prototype.setSubmitting.call(
+                submitGuardContext,
+                true,
+            ),
+        ).not.toThrow();
+
+        const formWithoutButton = document.createElement("form");
+        expect(() =>
+            ImageUploadController.prototype.setSubmitting.call(
+                {
+                    hasSubmitLabelTarget: true,
+                    submitLabelTarget: document.createElement("span"),
+                    hasSubmitSpinnerTarget: true,
+                    submitSpinnerTarget: document.createElement("span"),
+                    hasFormTarget: true,
+                    formTarget: formWithoutButton,
+                },
+                false,
+            ),
+        ).not.toThrow();
     });
 });

--- a/js/tests/main.test.js
+++ b/js/tests/main.test.js
@@ -1,0 +1,131 @@
+/* global afterEach, beforeEach, describe, expect, jest, test */
+
+describe("main runtime bootstrap", () => {
+    function installMocks() {
+        jest.resetModules();
+
+        globalThis.__MAIN_TEST_MOCKS__ = {
+            applicationStart: jest.fn(() => ({
+                register: jest.fn(),
+            })),
+            initThemeFromCookie: jest.fn(),
+            initAdminRuntimeLifecycle: jest.fn(),
+            startNativeBridge: jest.fn(),
+            registerServiceWorker: jest.fn(),
+            initTurboScrollBehavior: jest.fn(),
+        };
+
+        jest.mock("@hotwired/stimulus", () => {
+            const actual = jest.requireActual("@hotwired/stimulus");
+
+            return {
+                __esModule: true,
+                Controller: actual.Controller,
+                Application: {
+                    start: globalThis.__MAIN_TEST_MOCKS__.applicationStart,
+                },
+            };
+        });
+
+        jest.mock("../lib/theme.js", () => ({
+            __esModule: true,
+            initThemeFromCookie:
+                globalThis.__MAIN_TEST_MOCKS__.initThemeFromCookie,
+        }));
+
+        jest.mock("../lib/admin_runtime.js", () => ({
+            __esModule: true,
+            initAdminRuntimeLifecycle:
+                globalThis.__MAIN_TEST_MOCKS__.initAdminRuntimeLifecycle,
+        }));
+
+        jest.mock("../lib/native_bridge.js", () => ({
+            __esModule: true,
+            startNativeBridge: globalThis.__MAIN_TEST_MOCKS__.startNativeBridge,
+        }));
+
+        jest.mock("../lib/pwa.js", () => ({
+            __esModule: true,
+            registerServiceWorker:
+                globalThis.__MAIN_TEST_MOCKS__.registerServiceWorker,
+        }));
+
+        jest.mock("../lib/turbo_scroll.js", () => ({
+            __esModule: true,
+            initTurboScrollBehavior:
+                globalThis.__MAIN_TEST_MOCKS__.initTurboScrollBehavior,
+        }));
+
+        return globalThis.__MAIN_TEST_MOCKS__;
+    }
+
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        delete window.__RH_RUNTIME_BOOTED__;
+        delete globalThis.__MAIN_TEST_MOCKS__;
+        window.history.replaceState({}, "", "/");
+    });
+
+    afterEach(() => {
+        delete window.__RH_RUNTIME_BOOTED__;
+        delete globalThis.__MAIN_TEST_MOCKS__;
+        jest.resetModules();
+        jest.restoreAllMocks();
+        window.history.replaceState({}, "", "/");
+    });
+
+    test("boots public runtime once and registers controllers", async () => {
+        const mocks = installMocks();
+
+        await import("../main.js");
+
+        expect(window.__RH_RUNTIME_BOOTED__).toBe(true);
+        expect(window.Turbo).toBeTruthy();
+        expect(mocks.initThemeFromCookie).toHaveBeenCalledTimes(1);
+        expect(mocks.initAdminRuntimeLifecycle).not.toHaveBeenCalled();
+        expect(mocks.startNativeBridge).toHaveBeenCalledTimes(1);
+        expect(mocks.registerServiceWorker).toHaveBeenCalledTimes(1);
+        expect(mocks.initTurboScrollBehavior).toHaveBeenCalledTimes(1);
+
+        expect(mocks.applicationStart).toHaveBeenCalledTimes(1);
+        const stimulus = mocks.applicationStart.mock.results[0].value;
+        expect(stimulus.register).toHaveBeenCalledWith(
+            "image-selector",
+            expect.any(Function),
+        );
+        expect(stimulus.register).toHaveBeenCalledWith(
+            "theme-toggle",
+            expect.any(Function),
+        );
+
+        await import("../main.js");
+        expect(mocks.applicationStart).toHaveBeenCalledTimes(1);
+    });
+
+    test("boots admin runtime without theme bootstrap", async () => {
+        window.history.replaceState({}, "", "/admin/dashboard");
+
+        const mocks = installMocks();
+
+        await import("../main.js");
+
+        expect(mocks.initAdminRuntimeLifecycle).toHaveBeenCalledTimes(1);
+        expect(mocks.initThemeFromCookie).not.toHaveBeenCalled();
+        expect(mocks.registerServiceWorker).toHaveBeenCalledTimes(1);
+    });
+
+    test("does nothing when runtime boot flag is already set", async () => {
+        window.__RH_RUNTIME_BOOTED__ = true;
+
+        const mocks = installMocks();
+
+        await import("../main.js");
+
+        expect(mocks.applicationStart).not.toHaveBeenCalled();
+        expect(mocks.initThemeFromCookie).not.toHaveBeenCalled();
+        expect(mocks.initAdminRuntimeLifecycle).not.toHaveBeenCalled();
+        expect(mocks.startNativeBridge).not.toHaveBeenCalled();
+        expect(mocks.registerServiceWorker).not.toHaveBeenCalled();
+        expect(mocks.initTurboScrollBehavior).not.toHaveBeenCalled();
+    });
+});

--- a/js/tests/person_form_controller.test.js
+++ b/js/tests/person_form_controller.test.js
@@ -1,4 +1,4 @@
-/* global afterEach, beforeEach, describe, expect, jest, test */
+/* global Blob, afterEach, beforeEach, describe, expect, jest, test */
 
 import { Application } from "@hotwired/stimulus";
 
@@ -6,6 +6,7 @@ import PersonFormController from "../controllers/person_form_controller.js";
 
 describe("person-form controller", () => {
     let application;
+    let originalXmlHttpRequest;
 
     function flush() {
         return new Promise((resolve) => {
@@ -14,7 +15,9 @@ describe("person-form controller", () => {
     }
 
     beforeEach(() => {
+        originalXmlHttpRequest = window.XMLHttpRequest;
         document.body.innerHTML = `
+            <meta name="csrfToken" content="csrf-value" />
             <div
                 data-controller="person-form"
                 data-person-form-initial-image-id-value="42"
@@ -45,6 +48,7 @@ describe("person-form controller", () => {
             application = null;
         }
 
+        window.XMLHttpRequest = originalXmlHttpRequest;
         delete window.tinymce;
         document.body.innerHTML = "";
     });
@@ -77,6 +81,25 @@ describe("person-form controller", () => {
         expect(previewImg.src).toContain("_ts=");
     });
 
+    test("hides preview when image id is invalid and supports selected image url fallback", async () => {
+        await flush();
+
+        const imageField = document.getElementById("person-image-field");
+        const imagePreview = document.getElementById("person-image-preview");
+        const previewImg = imagePreview.querySelector("img");
+
+        imageField.value = "abc";
+        imageField.dataset.selectedImageUrl = "/img/storage/fallback.jpg";
+        imageField.dispatchEvent(new Event("change", { bubbles: true }));
+
+        expect(imagePreview.style.display).toBe("none");
+
+        imageField.value = "31";
+        imageField.dispatchEvent(new Event("change", { bubbles: true }));
+        expect(imagePreview.style.display).toBe("block");
+        expect(previewImg.src).toContain("/img/storage/fallback.jpg");
+    });
+
     test("uses initial preview url when matching initial image id", async () => {
         await flush();
 
@@ -97,5 +120,137 @@ describe("person-form controller", () => {
         document.dispatchEvent(new Event("turbo:before-cache"));
 
         expect(window.tinymce.remove).toHaveBeenCalledWith("#bio-editor");
+    });
+
+    test("skips TinyMCE init when editor has no id", async () => {
+        application.stop();
+        application = null;
+
+        document.body.innerHTML = `
+            <div data-controller="person-form">
+                <textarea data-person-form-target="bioEditor"></textarea>
+            </div>
+        `;
+
+        window.tinymce = {
+            get: jest.fn(() => null),
+            init: jest.fn(),
+            remove: jest.fn(),
+        };
+
+        application = Application.start();
+        application.register("person-form", PersonFormController);
+
+        await flush();
+
+        expect(window.tinymce.get).not.toHaveBeenCalled();
+        expect(window.tinymce.init).not.toHaveBeenCalled();
+    });
+
+    test("handles TinyMCE image upload success and progress", async () => {
+        await flush();
+
+        const xhr = {
+            upload: {},
+            headers: {},
+            open: jest.fn(),
+            setRequestHeader: jest.fn((key, value) => {
+                xhr.headers[key] = value;
+            }),
+            send: jest.fn((formData) => {
+                xhr.upload.onprogress({
+                    lengthComputable: true,
+                    loaded: 5,
+                    total: 10,
+                });
+                xhr.formData = formData;
+                xhr.onload();
+            }),
+            status: 200,
+            responseText: JSON.stringify({
+                success: true,
+                image: { url: "/img/storage/uploaded.jpg" },
+            }),
+        };
+        window.XMLHttpRequest = jest.fn(() => xhr);
+
+        const initConfig = window.tinymce.init.mock.calls[0][0];
+        const progress = jest.fn();
+        const blobInfo = {
+            blob: () => new Blob(["img"], { type: "image/jpeg" }),
+            filename: () => "upload.jpg",
+        };
+
+        await expect(
+            initConfig.images_upload_handler(blobInfo, progress),
+        ).resolves.toBe("/img/storage/uploaded.jpg");
+
+        expect(progress).toHaveBeenCalledWith(50);
+        expect(window.XMLHttpRequest).toHaveBeenCalledTimes(1);
+        expect(xhr.open).toHaveBeenCalledWith("POST", "/admin/images/upload");
+        expect(xhr.headers["X-CSRF-Token"]).toBe("csrf-value");
+        expect(xhr.formData.get("upload")).toBeInstanceOf(Blob);
+    });
+
+    test("handles TinyMCE image upload error branches", async () => {
+        await flush();
+
+        const initConfig = window.tinymce.init.mock.calls[0][0];
+        const blobInfo = {
+            blob: () => new Blob(["img"], { type: "image/jpeg" }),
+            filename: () => "upload.jpg",
+        };
+
+        const httpErrorXhr = {
+            upload: {},
+            open: jest.fn(),
+            setRequestHeader: jest.fn(),
+            send: jest.fn(() => httpErrorXhr.onload()),
+            status: 500,
+            responseText: "",
+        };
+        window.XMLHttpRequest = jest.fn(() => httpErrorXhr);
+        await expect(
+            initConfig.images_upload_handler(blobInfo, jest.fn()),
+        ).rejects.toBe("HTTP Error: 500");
+
+        const invalidJsonXhr = {
+            upload: {},
+            open: jest.fn(),
+            setRequestHeader: jest.fn(),
+            send: jest.fn(() => invalidJsonXhr.onload()),
+            status: 200,
+            responseText: "not-json",
+        };
+        window.XMLHttpRequest = jest.fn(() => invalidJsonXhr);
+        await expect(
+            initConfig.images_upload_handler(blobInfo, jest.fn()),
+        ).rejects.toBe("Invalid JSON");
+
+        const uploadErrorXhr = {
+            upload: {},
+            open: jest.fn(),
+            setRequestHeader: jest.fn(),
+            send: jest.fn(() => uploadErrorXhr.onload()),
+            status: 200,
+            responseText: JSON.stringify({ success: false, error: "Nope" }),
+        };
+        window.XMLHttpRequest = jest.fn(() => uploadErrorXhr);
+        await expect(
+            initConfig.images_upload_handler(blobInfo, jest.fn()),
+        ).rejects.toBe("Nope");
+
+        const networkErrorXhr = {
+            upload: {},
+            open: jest.fn(),
+            setRequestHeader: jest.fn(),
+            send: jest.fn(() => networkErrorXhr.onerror()),
+            status: 200,
+            responseText: "",
+        };
+        window.XMLHttpRequest = jest.fn(() => networkErrorXhr);
+        await expect(
+            initConfig.images_upload_handler(blobInfo, jest.fn()),
+        ).rejects.toBe("Image upload failed");
     });
 });

--- a/js/tests/persons_index_controller.test.js
+++ b/js/tests/persons_index_controller.test.js
@@ -150,6 +150,488 @@ describe("persons-index controller", () => {
 
         expect(dataTableApi.destroy).not.toHaveBeenCalled();
     });
+
+    test("toggles select-all and syncs state on draw callback", () => {
+        jest.advanceTimersByTime(0);
+
+        const tableBody = document.querySelector("#persons-table tbody");
+        tableBody.innerHTML = `
+            <tr><td><input type="checkbox" class="person-checkbox" value="101"></td></tr>
+            <tr><td><input type="checkbox" class="person-checkbox" value="202"></td></tr>
+        `;
+
+        const selectAll = document.getElementById("select-all-persons");
+        selectAll.checked = true;
+        selectAll.dispatchEvent(new Event("change", { bubbles: true }));
+
+        const checkboxes = tableBody.querySelectorAll(".person-checkbox");
+        expect(checkboxes[0].checked).toBe(true);
+        expect(checkboxes[1].checked).toBe(true);
+
+        const drawHandler = dataTableApi.on.mock.calls.find(
+            (call) => call[0] === "draw",
+        )[1];
+
+        checkboxes[1].checked = false;
+        drawHandler();
+        expect(selectAll.checked).toBe(false);
+
+        checkboxes[1].checked = true;
+        drawHandler();
+        expect(selectAll.checked).toBe(true);
+    });
+
+    test("guards bulk delete when action, selection, or confirm helper are unavailable", () => {
+        jest.advanceTimersByTime(0);
+
+        const tableBody = document.querySelector("#persons-table tbody");
+        const actionSelect = document.getElementById(
+            "bulk-action-select-persons",
+        );
+        const bulkButton = document.getElementById("bulk-action-btn-persons");
+
+        tableBody.innerHTML =
+            '<tr><td><input type="checkbox" class="person-checkbox" value="101"></td></tr>';
+
+        bulkButton.click();
+        expect(window.__rhStimulusShowConfirmDelete).not.toHaveBeenCalled();
+
+        tableBody.querySelector(".person-checkbox").checked = true;
+        bulkButton.click();
+        expect(window.__rhStimulusShowConfirmDelete).not.toHaveBeenCalled();
+
+        actionSelect.value = "archive";
+        actionSelect.dispatchEvent(new Event("change", { bubbles: true }));
+        bulkButton.click();
+        expect(window.__rhStimulusShowConfirmDelete).not.toHaveBeenCalled();
+
+        actionSelect.value = "delete";
+        actionSelect.dispatchEvent(new Event("change", { bubbles: true }));
+        delete window.__rhStimulusShowConfirmDelete;
+
+        bulkButton.click();
+        expect(window.__rhStimulusShowConfirmDelete).toBeUndefined();
+    });
+
+    test("retries DataTables initialization and skips when table URL is missing", () => {
+        jQueryMock.fn.DataTable = undefined;
+
+        jest.advanceTimersByTime(0);
+        expect(dataTableFactory).not.toHaveBeenCalled();
+
+        jQueryMock.fn.DataTable = function () {
+            return null;
+        };
+        jQueryMock.fn.DataTable.isDataTable = jest.fn(() => false);
+
+        jest.advanceTimersByTime(200);
+        expect(dataTableFactory).toHaveBeenCalledTimes(1);
+
+        application.stop();
+        application = null;
+
+        document.body.innerHTML = `
+            <div data-controller="persons-index">
+                <table id="persons-table" data-persons-index-target="table"></table>
+            </div>
+        `;
+
+        application = Application.start();
+        application.register("persons-index", PersonsIndexController);
+
+        jest.advanceTimersByTime(0);
+        expect(dataTableFactory).toHaveBeenCalledTimes(1);
+    });
+
+    test("handles DataTable destroy errors safely on disconnect", () => {
+        dataTableApi.destroy.mockImplementation(() => {
+            throw new Error("destroy failed");
+        });
+
+        jest.advanceTimersByTime(0);
+
+        expect(() => application.stop()).not.toThrow();
+        application = null;
+    });
+});
+
+describe("persons-index controller branch coverage", () => {
+    let application;
+    let drawMock;
+    let dataTableApi;
+    let dataTableFactory;
+    let jQueryMock;
+
+    const startController = ({
+        includeTable = true,
+        datatablesUrl = "/admin/persons/datatables",
+        includeSearchInput = true,
+        includeSelectAll = true,
+        includeBulkBar = true,
+        includeActionSelect = true,
+        includeBulkButton = true,
+        includeBulkForm = true,
+        includeRows = true,
+    } = {}) => {
+        const rowsMarkup = includeRows
+            ? `
+                <tr><td><input type="checkbox" class="person-checkbox" value="101"></td></tr>
+                <tr><td><input type="checkbox" class="person-checkbox" value="202"></td></tr>
+              `
+            : "";
+
+        document.body.innerHTML = `
+            <div
+                data-controller="persons-index"
+                data-persons-index-bulk-delete-url-value="/admin/persons/bulk-delete"
+            >
+                ${
+                    includeBulkBar
+                        ? '<div id="persons-bulk-action-bar" data-persons-index-target="bulkBar" style="display: none;"></div>'
+                        : ""
+                }
+                ${
+                    includeActionSelect
+                        ? `<select id="bulk-action-select-persons" data-persons-index-target="actionSelect">
+                        <option value="">Choose...</option>
+                        <option value="delete">Delete</option>
+                        <option value="archive">Archive</option>
+                    </select>`
+                        : ""
+                }
+                ${
+                    includeBulkButton
+                        ? '<button id="bulk-action-btn-persons" data-persons-index-target="bulkButton" disabled>Go</button>'
+                        : ""
+                }
+                ${
+                    includeSearchInput
+                        ? '<input id="persons-search" data-persons-index-target="searchInput" />'
+                        : ""
+                }
+                ${
+                    includeTable
+                        ? `<table
+                        id="persons-table"
+                        data-persons-index-target="table"
+                        ${datatablesUrl ? `data-datatables-url="${datatablesUrl}"` : ""}
+                    >
+                        <tbody>${rowsMarkup}</tbody>
+                    </table>`
+                        : ""
+                }
+                ${
+                    includeSelectAll
+                        ? '<input type="checkbox" id="select-all-persons" data-persons-index-target="selectAll" />'
+                        : ""
+                }
+                ${
+                    includeBulkForm
+                        ? '<form id="delete-form-persons-bulk" data-persons-index-target="bulkForm"></form>'
+                        : ""
+                }
+            </div>
+        `;
+
+        window.__rhStimulusShowConfirmDelete = jest.fn();
+
+        drawMock = jest.fn();
+        dataTableApi = {
+            destroy: jest.fn(),
+            on: jest.fn(),
+            search: jest.fn(() => ({ draw: drawMock })),
+        };
+        dataTableFactory = jest.fn(() => dataTableApi);
+
+        jQueryMock = jest.fn(() => ({
+            DataTable: dataTableFactory,
+        }));
+        jQueryMock.fn = {
+            DataTable: function () {
+                return null;
+            },
+        };
+        jQueryMock.fn.DataTable.isDataTable = jest.fn(() => false);
+
+        window.jQuery = jQueryMock;
+        window.$ = jQueryMock;
+
+        application = Application.start();
+        application.register("persons-index", PersonsIndexController);
+
+        const root = document.querySelector(
+            '[data-controller="persons-index"]',
+        );
+
+        return {
+            getController: async () => {
+                for (let i = 0; i < 4; i += 1) {
+                    const controller =
+                        application.getControllerForElementAndIdentifier(
+                            root,
+                            "persons-index",
+                        ) ||
+                        application.controllers.find(
+                            (item) => item.identifier === "persons-index",
+                        );
+
+                    if (controller) {
+                        return controller;
+                    }
+
+                    await Promise.resolve();
+                }
+
+                return undefined;
+            },
+        };
+    };
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        if (application) {
+            application.stop();
+            application = null;
+        }
+
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+
+        delete window.__rhStimulusShowConfirmDelete;
+        delete window.jQuery;
+        delete window.$;
+        document.body.innerHTML = "";
+    });
+
+    test("disconnect timer and listener branches plus jQuery fallback handle", async () => {
+        const mounted = startController();
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        const clearTimeoutSpy = jest.spyOn(window, "clearTimeout");
+
+        controller.searchDebounce = 10;
+        controller.initTimer = 20;
+        controller.dataTablesRetryTimer = 30;
+        controller.disconnect();
+
+        expect(clearTimeoutSpy).toHaveBeenCalledWith(10);
+        expect(clearTimeoutSpy).toHaveBeenCalledWith(20);
+        expect(clearTimeoutSpy).toHaveBeenCalledWith(30);
+
+        const noOptionalMounted = startController({
+            includeSearchInput: false,
+            includeSelectAll: false,
+            includeActionSelect: false,
+            includeBulkButton: false,
+        });
+        jest.advanceTimersByTime(0);
+        const noOptionalController = await noOptionalMounted.getController();
+
+        expect(() => noOptionalController.disconnect()).not.toThrow();
+
+        window.jQuery = null;
+        window.$ = { marker: "fallback" };
+        expect(noOptionalController.jQueryHandle()).toEqual({
+            marker: "fallback",
+        });
+
+        clearTimeoutSpy.mockRestore();
+    });
+
+    test("DataTables availability and init retry/max/table-target guards", async () => {
+        const noTableMounted = startController({ includeTable: false });
+        jest.advanceTimersByTime(0);
+        const noTableController = await noTableMounted.getController();
+
+        const setTimeoutSpy = jest.spyOn(window, "setTimeout");
+        noTableController.initDataTableWhenReady();
+        expect(setTimeoutSpy).not.toHaveBeenCalled();
+
+        const mounted = startController();
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        window.jQuery = null;
+        window.$ = null;
+        expect(controller.isDataTablesAvailable()).toBe(false);
+
+        window.$ = { fn: {} };
+        expect(controller.isDataTablesAvailable()).toBe(false);
+
+        window.$ = {
+            fn: {
+                DataTable: {},
+            },
+        };
+        expect(controller.isDataTablesAvailable()).toBe(false);
+
+        window.jQuery = jQueryMock;
+        window.$ = jQueryMock;
+
+        const availSpy = jest
+            .spyOn(controller, "isDataTablesAvailable")
+            .mockReturnValue(false);
+
+        setTimeoutSpy.mockClear();
+        controller.dataTablesRetryCount = 0;
+        controller.initDataTableWhenReady();
+        expect(controller.dataTablesRetryCount).toBe(1);
+        expect(setTimeoutSpy).toHaveBeenCalled();
+
+        if (controller.dataTablesRetryTimer) {
+            window.clearTimeout(controller.dataTablesRetryTimer);
+            controller.dataTablesRetryTimer = null;
+        }
+
+        setTimeoutSpy.mockClear();
+        controller.dataTablesRetryCount = 30;
+        controller.initDataTableWhenReady();
+        expect(setTimeoutSpy).not.toHaveBeenCalled();
+
+        availSpy.mockRestore();
+        setTimeoutSpy.mockRestore();
+    });
+
+    test("initDataTable handles jq/table guards, missing URL, existing table destroy, and on-listener guard", async () => {
+        const mounted = startController();
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        window.jQuery = null;
+        window.$ = null;
+        controller.initDataTable();
+
+        window.jQuery = jQueryMock;
+        window.$ = jQueryMock;
+
+        const noUrlMounted = startController({ datatablesUrl: "" });
+        jest.advanceTimersByTime(0);
+        const noUrlController = await noUrlMounted.getController();
+
+        dataTableFactory.mockClear();
+        noUrlController.initDataTable();
+        expect(dataTableFactory).not.toHaveBeenCalled();
+
+        const destroySpy = jest.spyOn(controller, "destroyTable");
+        jQueryMock.fn.DataTable.isDataTable = jest.fn(() => true);
+        controller.initDataTable();
+        expect(destroySpy).toHaveBeenCalled();
+
+        jQueryMock.fn.DataTable.isDataTable = jest.fn(() => false);
+        dataTableApi.on = undefined;
+        expect(() => controller.initDataTable()).not.toThrow();
+
+        destroySpy.mockRestore();
+    });
+
+    test("search debounce covers guard, clear, and delayed guard branches", async () => {
+        const mounted = startController();
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        controller.dtInstance = null;
+        expect(() => controller.onSearchInput()).not.toThrow();
+
+        controller.dtInstance = dataTableApi;
+        controller.searchDebounce = 55;
+        const clearTimeoutSpy = jest.spyOn(window, "clearTimeout");
+
+        controller.searchInputTarget.value = "Alpha";
+        controller.onSearchInput();
+        expect(clearTimeoutSpy).toHaveBeenCalledWith(55);
+
+        jest.advanceTimersByTime(250);
+        expect(dataTableApi.search).toHaveBeenCalledWith("Alpha");
+
+        const delayedSearchApi = {
+            search: jest.fn(() => ({ draw: jest.fn() })),
+        };
+        const delayedContext = {
+            dtInstance: delayedSearchApi,
+            hasSearchInputTarget: true,
+            searchInputTarget: { value: "Gamma" },
+            searchDebounce: null,
+        };
+        PersonsIndexController.prototype.onSearchInput.call(delayedContext);
+        delayedContext.dtInstance = null;
+        jest.advanceTimersByTime(250);
+        expect(delayedSearchApi.search).not.toHaveBeenCalled();
+
+        dataTableApi.search.mockClear();
+        controller.dtInstance = dataTableApi;
+        controller.searchInputTarget.value = "Beta";
+        controller.onSearchInput();
+        jest.advanceTimersByTime(250);
+        expect(dataTableApi.search).toHaveBeenCalledWith("Beta");
+
+        clearTimeoutSpy.mockRestore();
+    });
+
+    test("checkbox and select-all guards cover missing targets and empty table states", async () => {
+        const noTableMounted = startController({ includeTable: false });
+        jest.advanceTimersByTime(0);
+        const noTableController = await noTableMounted.getController();
+
+        expect(noTableController.checkedCheckboxes()).toEqual([]);
+
+        const noSelectMounted = startController({ includeSelectAll: false });
+        jest.advanceTimersByTime(0);
+        const noSelectController = await noSelectMounted.getController();
+        expect(() => noSelectController.syncSelectAllState()).not.toThrow();
+
+        const emptyMounted = startController({ includeRows: false });
+        jest.advanceTimersByTime(0);
+        const emptyController = await emptyMounted.getController();
+        emptyController.syncSelectAllState();
+        expect(emptyController.selectAllTarget.checked).toBe(false);
+
+        const noTableForSelectMounted = startController({
+            includeTable: false,
+        });
+        jest.advanceTimersByTime(0);
+        const noTableForSelectController =
+            await noTableForSelectMounted.getController();
+        expect(() =>
+            noTableForSelectController.onSelectAllChange(),
+        ).not.toThrow();
+    });
+
+    test("bulk button guard paths and fallback formId branch", async () => {
+        const mounted = startController({ includeBulkForm: false });
+        jest.advanceTimersByTime(0);
+        const controller = await mounted.getController();
+
+        controller.onBulkButtonClick();
+        expect(window.__rhStimulusShowConfirmDelete).not.toHaveBeenCalled();
+
+        const checkboxes =
+            controller.tableTarget.querySelectorAll(".person-checkbox");
+        checkboxes[0].checked = true;
+
+        controller.actionSelectTarget.value = "archive";
+        controller.onBulkButtonClick();
+        expect(window.__rhStimulusShowConfirmDelete).not.toHaveBeenCalled();
+
+        controller.actionSelectTarget.value = "delete";
+        const originalBridge = window.__rhStimulusShowConfirmDelete;
+        window.__rhStimulusShowConfirmDelete = undefined;
+        controller.onBulkButtonClick();
+        expect(originalBridge).not.toHaveBeenCalled();
+
+        window.__rhStimulusShowConfirmDelete = jest.fn();
+        controller.onBulkButtonClick();
+        expect(window.__rhStimulusShowConfirmDelete).toHaveBeenCalledWith(
+            expect.objectContaining({
+                formId: "delete-form-persons-bulk",
+                idsName: "person_ids[]",
+                bulkAction: "delete",
+            }),
+        );
+    });
 });
 
 function SEARCH_DEBOUNCE_MS() {

--- a/js/tests/place_search_controller.test.js
+++ b/js/tests/place_search_controller.test.js
@@ -1,0 +1,148 @@
+/* global MouseEvent, afterEach, beforeEach, describe, expect, jest, test */
+
+import { Application } from "@hotwired/stimulus";
+
+import PlaceSearchController from "../controllers/place_search_controller.js";
+
+const flushPromises = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+};
+
+describe("place-search controller", () => {
+    let application;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        globalThis.fetch = jest.fn();
+
+        document.body.innerHTML = `
+            <div
+                data-controller="place-search"
+                data-place-search-search-url-value="/places/search"
+            >
+                <input
+                    id="place-search-input"
+                    data-place-search-target="input"
+                    data-action="input->place-search#search"
+                />
+                <div id="place-search-results" data-place-search-target="results"></div>
+                <div id="place-search-selected" data-place-search-target="selected">
+                    <span class="text-muted fst-italic">None selected</span>
+                </div>
+                <input id="place-search-hidden" data-place-search-target="hidden" />
+            </div>
+        `;
+
+        application = Application.start();
+        application.register("place-search", PlaceSearchController);
+    });
+
+    afterEach(() => {
+        if (application) {
+            application.stop();
+            application = null;
+        }
+
+        delete globalThis.fetch;
+        document.body.innerHTML = "";
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+    });
+
+    test("ignores short queries and clears stale results", () => {
+        const results = document.getElementById("place-search-results");
+        const input = document.getElementById("place-search-input");
+
+        results.innerHTML = '<div class="stale">Old result</div>';
+        input.value = "A";
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+
+        expect(results.innerHTML).toBe("");
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    test("searches, renders results, selects a place, and clears it again", async () => {
+        fetch.mockResolvedValue({
+            json: async () => ({
+                success: true,
+                results: [
+                    { id: 8, place_city: "Nashville", place_state: "TN" },
+                ],
+            }),
+        });
+
+        const input = document.getElementById("place-search-input");
+        const results = document.getElementById("place-search-results");
+        const hidden = document.getElementById("place-search-hidden");
+        const selected = document.getElementById("place-search-selected");
+
+        input.value = "Na";
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+
+        jest.advanceTimersByTime(300);
+        await flushPromises();
+
+        expect(fetch).toHaveBeenCalledWith("/places/search?q=Na", {
+            headers: {
+                "X-Requested-With": "XMLHttpRequest",
+            },
+        });
+        expect(results.innerHTML).toContain("Nashville, TN");
+
+        results.querySelector("button").click();
+
+        expect(hidden.value).toBe("8");
+        expect(selected.innerHTML).toContain("Nashville, TN");
+        expect(results.innerHTML).toBe("");
+        expect(input.value).toBe("");
+
+        selected.querySelector(".clear-birth-place").click();
+
+        expect(hidden.value).toBe("");
+        expect(selected.textContent).toContain("None selected");
+    });
+
+    test("shows empty and error states, handles global selection, and cleans up on disconnect", async () => {
+        const input = document.getElementById("place-search-input");
+        const results = document.getElementById("place-search-results");
+        const hidden = document.getElementById("place-search-hidden");
+
+        fetch.mockResolvedValueOnce({
+            json: async () => ({ success: true, results: [] }),
+        });
+
+        input.value = "No";
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+        jest.advanceTimersByTime(300);
+        await flushPromises();
+
+        expect(results.innerHTML).toContain("No results");
+
+        fetch.mockRejectedValueOnce(new Error("network"));
+        input.value = "Er";
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+        jest.advanceTimersByTime(300);
+        await flushPromises();
+
+        expect(results.innerHTML).toContain("Error");
+
+        window.handleBirthPlaceAdded({
+            place: { id: 13, place_city: "Paris", place_state: "KY" },
+        });
+
+        expect(hidden.value).toBe("13");
+        expect(
+            document.getElementById("place-search-selected").innerHTML,
+        ).toContain("Paris, KY");
+
+        results.innerHTML = '<button type="button">Visible</button>';
+        document.body.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        expect(results.innerHTML).toBe("");
+
+        document.querySelector('[data-controller="place-search"]').remove();
+        await flushPromises();
+
+        expect(window.handleBirthPlaceAdded).toBeUndefined();
+    });
+});

--- a/js/tests/roster_edit_person_controller.test.js
+++ b/js/tests/roster_edit_person_controller.test.js
@@ -1,0 +1,189 @@
+/* global afterEach, beforeEach, describe, expect, jest, test */
+
+import { Application } from "@hotwired/stimulus";
+
+import RosterEditPersonController from "../controllers/roster_edit_person_controller.js";
+
+const flushPromises = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+};
+
+describe("roster-edit-person controller", () => {
+    let application;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        globalThis.fetch = jest.fn();
+
+        document.body.innerHTML = `
+            <div
+                data-controller="roster-edit-person"
+                data-roster-edit-person-search-url-value="/admin/people/search"
+                data-roster-edit-person-current-id-value="5"
+                data-roster-edit-person-current-label-value="Current Person"
+            >
+                <div id="select-wrapper">
+                    <select data-roster-edit-person-target="select" class="form-select">
+                        <option value="">(Select a person)</option>
+                    </select>
+                </div>
+            </div>
+        `;
+
+        application = Application.start();
+        application.register("roster-edit-person", RosterEditPersonController);
+    });
+
+    afterEach(() => {
+        if (application) {
+            application.stop();
+            application = null;
+        }
+
+        delete globalThis.fetch;
+        document.body.innerHTML = "";
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+    });
+
+    test("injects search input and ensures the current option exists", () => {
+        const wrapper = document.querySelector(".dynamic-person-wrapper");
+        const searchInput = document.querySelector(".roster-person-filter");
+        const select = document.querySelector("select");
+
+        expect(wrapper).not.toBeNull();
+        expect(searchInput).not.toBeNull();
+        expect(select.value).toBe("5");
+        expect(select.querySelector('option[value="5"]').textContent).toBe(
+            "Current Person",
+        );
+    });
+
+    test("uses an existing wrapper when present and does not duplicate controls", () => {
+        application.stop();
+        application = null;
+
+        document.body.innerHTML = `
+            <div
+                data-controller="roster-edit-person"
+                data-roster-edit-person-search-url-value="/admin/people/search"
+            >
+                <div class="dynamic-person-wrapper">
+                    <input class="roster-person-filter" type="text" />
+                    <select data-roster-edit-person-target="select" class="form-select">
+                        <option value="">(Select a person)</option>
+                    </select>
+                </div>
+            </div>
+        `;
+
+        application = Application.start();
+        application.register("roster-edit-person", RosterEditPersonController);
+
+        expect(
+            document.querySelectorAll(".dynamic-person-wrapper"),
+        ).toHaveLength(1);
+        expect(document.querySelectorAll(".roster-person-filter")).toHaveLength(
+            1,
+        );
+    });
+
+    test("debounces searches, preserves current selection, and ignores duplicate queries", async () => {
+        await flushPromises();
+
+        fetch.mockResolvedValue({
+            json: async () => ({
+                success: true,
+                results: [
+                    { value: 7, text: "Alice Adams" },
+                    { value: 8, text: "Bob Brown" },
+                ],
+            }),
+        });
+
+        const searchInput = document.querySelector(".roster-person-filter");
+        const select = document.querySelector("select");
+
+        searchInput.value = "Al";
+        searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+        jest.advanceTimersByTime(300);
+        await flushPromises();
+        await flushPromises();
+
+        expect(fetch).toHaveBeenCalledWith("/admin/people/search?q=Al", {
+            credentials: "same-origin",
+            headers: { "X-Requested-With": "XMLHttpRequest" },
+        });
+        expect(select.querySelector('option[value=""]').textContent).toBe(
+            "(Select a person)",
+        );
+        expect(select.querySelector('option[value="5"]').textContent).toBe(
+            "Current Person",
+        );
+        expect(select.querySelector('option[value="7"]').textContent).toBe(
+            "Alice Adams",
+        );
+        expect(select.value).toBe("5");
+
+        searchInput.value = "Al";
+        searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+        jest.advanceTimersByTime(300);
+        await flushPromises();
+        await flushPromises();
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+
+        searchInput.value = "A";
+        searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+        jest.advanceTimersByTime(300);
+        await flushPromises();
+        await flushPromises();
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    test("keeps options stable on invalid or failing responses and clears timers on disconnect", async () => {
+        await flushPromises();
+
+        fetch
+            .mockResolvedValueOnce({
+                json: async () => ({ success: false, results: null }),
+            })
+            .mockRejectedValueOnce(new Error("network"))
+            .mockResolvedValue({
+                json: async () => ({ success: true, results: [] }),
+            });
+
+        const searchInput = document.querySelector(".roster-person-filter");
+        const select = document.querySelector("select");
+
+        searchInput.value = "No";
+        searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+        jest.advanceTimersByTime(300);
+        await flushPromises();
+        await flushPromises();
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(select.querySelector('option[value="5"]').textContent).toBe(
+            "Current Person",
+        );
+
+        searchInput.value = "Er";
+        searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+        jest.advanceTimersByTime(300);
+        await flushPromises();
+        await flushPromises();
+        expect(fetch).toHaveBeenCalledTimes(2);
+
+        searchInput.value = "Late";
+        searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+        document
+            .querySelector('[data-controller="roster-edit-person"]')
+            .remove();
+        await flushPromises();
+        jest.advanceTimersByTime(300);
+        await flushPromises();
+
+        expect(fetch).toHaveBeenCalledTimes(2);
+    });
+});

--- a/js/tests/roster_multi_add_controller.test.js
+++ b/js/tests/roster_multi_add_controller.test.js
@@ -1,0 +1,461 @@
+/* global MouseEvent, afterEach, beforeEach, describe, expect, jest, test */
+
+import { Application } from "@hotwired/stimulus";
+
+import RosterMultiAddController from "../controllers/roster_multi_add_controller.js";
+
+const flushPromises = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+};
+
+describe("roster-multi-add controller", () => {
+    let application;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        globalThis.fetch = jest.fn();
+
+        document.body.innerHTML = `
+            <div data-controller="roster-multi-add">
+                <div
+                    id="roster-rows"
+                    data-roster-multi-add-target="rows"
+                    data-person-search-url="/admin/people/search"
+                >
+                    <div class="roster-row" data-row-index="0">
+                        <input class="roster-person-search" name="rows[0][person_search]" />
+                        <input class="roster-person-id" name="rows[0][person_id]" value="12" />
+                        <div class="roster-person-selected">
+                            <span class="badge bg-primary me-1">
+                                Existing Person
+                                <button
+                                    type="button"
+                                    class="btn-close btn-close-white ms-1 roster-clear-person"
+                                ></button>
+                            </span>
+                        </div>
+                        <div class="roster-person-results"></div>
+                        <input type="hidden" name="rows[0][id]" value="44" />
+                        <button type="button" class="remove-row-btn">Remove</button>
+                    </div>
+                </div>
+                <button
+                    id="add-row-btn"
+                    type="button"
+                    data-roster-multi-add-target="addButton"
+                >
+                    Add row
+                </button>
+            </div>
+        `;
+
+        application = Application.start();
+        application.register("roster-multi-add", RosterMultiAddController);
+    });
+
+    afterEach(() => {
+        if (application) {
+            application.stop();
+            application = null;
+        }
+
+        delete globalThis.fetch;
+        delete window.onRosterPersonAdded;
+        document.body.innerHTML = "";
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+    });
+
+    test("adds/removes rows, reindexes inputs, and resets cloned fields", () => {
+        const rowsContainer = document.getElementById("roster-rows");
+        const addButton = document.getElementById("add-row-btn");
+
+        expect(rowsContainer.querySelector(".remove-row-btn").disabled).toBe(
+            true,
+        );
+
+        addButton.click();
+
+        const rows = rowsContainer.querySelectorAll(".roster-row");
+        const newRow = rows[1];
+
+        expect(rows).toHaveLength(2);
+        expect(rows[0].querySelector(".remove-row-btn").disabled).toBe(false);
+        expect(rows[1].querySelector(".remove-row-btn").disabled).toBe(false);
+        expect(newRow.dataset.rowIndex).toBe("1");
+        expect(
+            newRow.querySelector('[name="rows[1][person_search]"]'),
+        ).not.toBeNull();
+        expect(newRow.querySelector('[name="rows[1][person_id]"]').value).toBe(
+            "",
+        );
+        expect(newRow.querySelector('[name="rows[1][id]"]')).toBeNull();
+        expect(
+            newRow.querySelector(".roster-person-search").dataset.searchBound,
+        ).toBe("1");
+        expect(document.activeElement).toBe(
+            newRow.querySelector(".roster-person-search"),
+        );
+
+        rowsContainer.querySelector(".remove-row-btn").click();
+
+        const remainingRows = rowsContainer.querySelectorAll(".roster-row");
+        expect(remainingRows).toHaveLength(1);
+        expect(remainingRows[0].dataset.rowIndex).toBe("0");
+        expect(
+            remainingRows[0].querySelector('[name="rows[0][person_search]"]'),
+        ).not.toBeNull();
+        expect(remainingRows[0].querySelector(".remove-row-btn").disabled).toBe(
+            true,
+        );
+    });
+
+    test("searches and selects a person, then handles empty and network responses", async () => {
+        await flushPromises();
+
+        const searchInput = document.querySelector(".roster-person-search");
+        const hiddenInput = document.querySelector(".roster-person-id");
+        const results = document.querySelector(".roster-person-results");
+
+        searchInput.value = "A";
+        searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+        expect(results.innerHTML).toBe("");
+        expect(fetch).not.toHaveBeenCalled();
+
+        fetch
+            .mockResolvedValueOnce({
+                json: async () => ({
+                    success: true,
+                    results: [{ value: 99, text: "Alice" }],
+                }),
+            })
+            .mockResolvedValueOnce({
+                json: async () => ({
+                    success: true,
+                    results: [],
+                }),
+            })
+            .mockRejectedValueOnce(new Error("network"));
+
+        searchInput.value = "Al";
+        searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+        jest.advanceTimersByTime(300);
+        await flushPromises();
+        await flushPromises();
+
+        expect(fetch).toHaveBeenCalledWith("/admin/people/search?q=Al", {
+            signal: expect.anything(),
+            headers: { "X-Requested-With": "XMLHttpRequest" },
+        });
+        expect(results.innerHTML).toContain("Alice");
+
+        results.querySelector("button").click();
+
+        expect(hiddenInput.value).toBe("99");
+        expect(
+            document.querySelector(".roster-person-selected").innerHTML,
+        ).toContain("Alice");
+        expect(results.innerHTML).toBe("");
+        expect(searchInput.value).toBe("");
+
+        searchInput.value = "No";
+        searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+        jest.advanceTimersByTime(300);
+        await flushPromises();
+        await flushPromises();
+
+        expect(results.innerHTML).toContain("No results found");
+
+        searchInput.value = "Er";
+        searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+        jest.advanceTimersByTime(300);
+        await flushPromises();
+        await flushPromises();
+
+        expect(results.innerHTML).toContain("Network error");
+    });
+
+    test("aborts stale searches, supports global person add, and cleans up listeners", async () => {
+        await flushPromises();
+
+        const searchInput = document.querySelector(".roster-person-search");
+        const hiddenInput = document.querySelector(".roster-person-id");
+        const selected = document.querySelector(".roster-person-selected");
+        const addButton = document.getElementById("add-row-btn");
+
+        fetch
+            .mockImplementationOnce(() => new Promise(() => {}))
+            .mockResolvedValueOnce({
+                json: async () => ({
+                    success: true,
+                    results: [{ value: 100, text: "Abe" }],
+                }),
+            });
+
+        searchInput.value = "Ab";
+        searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+        jest.advanceTimersByTime(300);
+
+        const firstSignal = fetch.mock.calls[0][1].signal;
+        expect(firstSignal.aborted).toBe(false);
+
+        searchInput.value = "Abe";
+        searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+        jest.advanceTimersByTime(300);
+        await flushPromises();
+
+        expect(firstSignal.aborted).toBe(true);
+
+        document.querySelector(".roster-clear-person").click();
+        expect(hiddenInput.value).toBe("");
+        expect(selected.textContent).toContain("None selected");
+
+        addButton.click();
+        window.onRosterPersonAdded({
+            newOption: { value: "321", text: "Injected Player" },
+        });
+
+        const rows = document.querySelectorAll(".roster-row");
+        expect(rows[0].querySelector(".roster-person-id").value).toBe("321");
+        expect(rows[1].querySelector(".roster-person-id").value).toBe("321");
+
+        const results = document.querySelectorAll(".roster-person-results");
+        results[0].innerHTML = '<button type="button">Visible</button>';
+        document.body.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        expect(results[0].innerHTML).toBe("");
+
+        document.querySelector('[data-controller="roster-multi-add"]').remove();
+        await flushPromises();
+
+        expect(window.onRosterPersonAdded).toBeUndefined();
+    });
+});
+
+describe("roster-multi-add controller branch coverage", () => {
+    let application;
+
+    const renderFixture = ({
+        includeRowsTarget = true,
+        includeAddButtonTarget = true,
+        includeAddButton = true,
+        includeSearchUrl = true,
+        includeRow = true,
+    } = {}) => {
+        document.body.innerHTML = `
+            <div data-controller="roster-multi-add">
+                <div
+                    id="roster-rows"
+                    ${includeRowsTarget ? 'data-roster-multi-add-target="rows"' : ""}
+                    ${includeSearchUrl ? 'data-person-search-url="/admin/people/search"' : ""}
+                >
+                    ${
+                        includeRow
+                            ? `<div class="roster-row" data-row-index="0">
+                                <input class="roster-person-search" name="rows[0][person_search]" />
+                                <input class="roster-person-id" name="rows[0][person_id]" value="" />
+                                <div class="roster-person-selected"></div>
+                                <div class="roster-person-results"></div>
+                                <button type="button" class="remove-row-btn">Remove</button>
+                            </div>`
+                            : ""
+                    }
+                </div>
+                ${
+                    includeAddButton
+                        ? `<button id="add-row-btn" type="button" ${includeAddButtonTarget ? 'data-roster-multi-add-target="addButton"' : ""}>Add</button>`
+                        : ""
+                }
+            </div>
+        `;
+    };
+
+    const startController = async (options = {}) => {
+        renderFixture(options);
+
+        application = Application.start();
+        application.register("roster-multi-add", RosterMultiAddController);
+
+        const root = document.querySelector(
+            '[data-controller="roster-multi-add"]',
+        );
+        for (let i = 0; i < 4; i += 1) {
+            const controller =
+                application.getControllerForElementAndIdentifier(
+                    root,
+                    "roster-multi-add",
+                ) ||
+                application.controllers.find(
+                    (item) => item.identifier === "roster-multi-add",
+                );
+
+            if (controller) {
+                return controller;
+            }
+
+            await Promise.resolve();
+        }
+
+        return undefined;
+    };
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        globalThis.fetch = jest.fn();
+    });
+
+    afterEach(() => {
+        if (application) {
+            application.stop();
+            application = null;
+        }
+
+        delete globalThis.fetch;
+        delete window.onRosterPersonAdded;
+        document.body.innerHTML = "";
+        jest.restoreAllMocks();
+        jest.useRealTimers();
+    });
+
+    test("connect/disconnect fallback and guard branches", async () => {
+        const controller = await startController({
+            includeRowsTarget: false,
+            includeAddButtonTarget: false,
+            includeAddButton: false,
+            includeSearchUrl: false,
+        });
+
+        expect(controller.rowsElement().id).toBe("roster-rows");
+        expect(controller.addButtonElement()).toBeNull();
+
+        const keepHandler = () => {};
+        window.onRosterPersonAdded = keepHandler;
+        controller.disconnect();
+        expect(window.onRosterPersonAdded).toBe(keepHandler);
+
+        expect(() =>
+            RosterMultiAddController.prototype.disconnect.call({
+                rowsElement: () => null,
+                addButtonElement: () => null,
+                boundRowsClick: () => {},
+                boundAddClick: () => {},
+                boundDocumentClick: () => {},
+                boundPersonAdded: () => {},
+            }),
+        ).not.toThrow();
+    });
+
+    test("click handlers cover remove guards and outside/inside row behavior", async () => {
+        const controller = await startController();
+
+        controller.handleRowsClick({ target: document.createElement("div") });
+
+        const orphanRemove = document.createElement("button");
+        orphanRemove.className = "remove-row-btn";
+        controller.handleRowsClick({ target: orphanRemove });
+
+        const rows = document.querySelectorAll(".roster-row");
+        rows[0].querySelector(".roster-person-results").innerHTML = "x";
+        controller.handleDocumentClick({ target: rows[0] });
+        expect(rows[0].querySelector(".roster-person-results").innerHTML).toBe(
+            "x",
+        );
+
+        const noResultsRow = document.createElement("div");
+        noResultsRow.className = "roster-row";
+        document.getElementById("roster-rows").appendChild(noResultsRow);
+        controller.handleDocumentClick({ target: document.body });
+        expect(rows[0].querySelector(".roster-person-results").innerHTML).toBe(
+            "",
+        );
+    });
+
+    test("person add/init search/render/add/reindex/auto-select utility branches", async () => {
+        const controller = await startController();
+
+        controller.handlePersonAdded({});
+        controller.handlePersonAdded({ newOption: { value: "", text: "x" } });
+        controller.handlePersonAdded({
+            newOption: { value: "5", text: "Five" },
+        });
+
+        expect(() =>
+            controller.initPersonSearch(null, "/admin/people/search"),
+        ).not.toThrow();
+        expect(() =>
+            controller.initPersonSearch(
+                document.querySelector(".roster-row"),
+                "",
+            ),
+        ).not.toThrow();
+
+        const missingBits = document.createElement("div");
+        missingBits.className = "roster-row";
+        missingBits.innerHTML = '<input class="roster-person-search" />';
+        controller.initPersonSearch(missingBits, "/admin/people/search");
+
+        const boundRow = document.querySelector(".roster-row");
+        const boundInput = boundRow.querySelector(".roster-person-search");
+        boundInput.dataset.searchBound = "1";
+        controller.initPersonSearch(boundRow, "/admin/people/search");
+
+        const noSelectedRow = document.createElement("div");
+        noSelectedRow.className = "roster-row";
+        noSelectedRow.innerHTML =
+            '<input class="roster-person-search" /><input class="roster-person-id" /><div class="roster-person-results"></div>';
+        controller.initPersonSearch(noSelectedRow, "/admin/people/search");
+        noSelectedRow.querySelector(".roster-person-search").value = "ab";
+        globalThis.fetch.mockRejectedValueOnce({ name: "AbortError" });
+        noSelectedRow
+            .querySelector(".roster-person-search")
+            .dispatchEvent(new Event("input", { bubbles: true }));
+        jest.advanceTimersByTime(300);
+        await flushPromises();
+        expect(
+            noSelectedRow.querySelector(".roster-person-results").innerHTML,
+        ).toBe("");
+
+        controller.renderResults(
+            [{ value: 1 }, { value: 2, text: "Beta" }],
+            noSelectedRow.querySelector(".roster-person-results"),
+            jest.fn(),
+        );
+        expect(
+            noSelectedRow.querySelector(".roster-person-results").innerHTML,
+        ).toContain('data-id="1" data-text=""');
+
+        const rowsContainer = document.getElementById("roster-rows");
+        const row = rowsContainer.querySelector(".roster-row");
+        row.removeAttribute("data-row-index");
+        row.querySelector(".roster-person-selected").remove();
+        row.querySelector(".roster-person-results").remove();
+        const nameless = document.createElement("input");
+        row.appendChild(nameless);
+        row.querySelector(".roster-person-search").remove();
+
+        controller.addRow();
+        const newRow = rowsContainer.querySelectorAll(".roster-row")[1];
+        expect(newRow.dataset.rowIndex).toBe("1");
+
+        controller.reindexRows();
+        expect(() => controller.updateRemoveButtons()).not.toThrow();
+
+        const selectSpy = jest.fn();
+        const blankHidden = document.querySelector(".roster-person-id");
+        blankHidden.value = "already";
+        row._rosterSetSelected = selectSpy;
+        controller.autoSelectNewPerson("99", "Name");
+        expect(selectSpy).not.toHaveBeenCalled();
+
+        blankHidden.value = "";
+        controller.autoSelectNewPerson("99", "Name");
+        expect(selectSpy).toHaveBeenCalledWith("99", "Name");
+
+        const emptyRowsController = await startController({
+            includeRow: false,
+        });
+        expect(() => emptyRowsController.addRow()).not.toThrow();
+
+        expect(controller.escapeHtml("<tag>&\"'")).toBe("&lt;tag&gt;&amp;\"'");
+    });
+});

--- a/js/tests/stat_multi_add_controller.test.js
+++ b/js/tests/stat_multi_add_controller.test.js
@@ -1,0 +1,116 @@
+/* global afterEach, beforeEach, describe, expect, jest, test */
+
+import { Application } from "@hotwired/stimulus";
+
+import StatMultiAddController from "../controllers/stat_multi_add_controller.js";
+
+describe("stat-multi-add controller", () => {
+    let application;
+
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div data-controller="stat-multi-add">
+                <div id="stat-rows" data-stat-multi-add-target="rows">
+                    <div class="stat-row" data-row-index="0">
+                        <div class="stat-row-label">Player #1</div>
+                        <input class="stat-player-select" name="rows[0][player_id]" value="12" />
+                        <input type="hidden" name="rows[0][id]" value="55" />
+                        <input type="hidden" name="rows[0][GP]" value="1" />
+                        <input type="checkbox" name="rows[0][starter]" checked />
+                        <input name="rows[0][period]" value="Q1" />
+                        <select name="rows[0][stat_type]">
+                            <option value="points" selected>Points</option>
+                            <option value="assists">Assists</option>
+                        </select>
+                        <button type="button" class="remove-row-btn">Remove</button>
+                    </div>
+                </div>
+                <button id="add-stat-row" type="button" data-stat-multi-add-target="addButton">Add row</button>
+            </div>
+        `;
+
+        application = Application.start();
+        application.register("stat-multi-add", StatMultiAddController);
+    });
+
+    afterEach(() => {
+        if (application) {
+            application.stop();
+            application = null;
+        }
+
+        document.body.innerHTML = "";
+        jest.restoreAllMocks();
+    });
+
+    test("disables remove buttons when only one row exists", () => {
+        expect(document.querySelector(".remove-row-btn").disabled).toBe(true);
+    });
+
+    test("adds a row and resets cloned fields for the new index", () => {
+        document.getElementById("add-stat-row").click();
+
+        const rows = document.querySelectorAll(".stat-row");
+        const newRow = rows[1];
+
+        expect(rows).toHaveLength(2);
+        expect(newRow.dataset.rowIndex).toBe("1");
+        expect(newRow.querySelector(".stat-row-label").textContent).toBe(
+            "Player #2",
+        );
+        expect(newRow.querySelector('[name="rows[1][player_id]"]').value).toBe(
+            "",
+        );
+        expect(newRow.querySelector('[name="rows[1][id]"]').value).toBe("");
+        expect(newRow.querySelector('[name="rows[1][GP]"]').value).toBe("1");
+        expect(newRow.querySelector('[name="rows[1][starter]"]').checked).toBe(
+            false,
+        );
+        expect(newRow.querySelector('[name="rows[1][period]"]').value).toBe(
+            "Z",
+        );
+        expect(newRow.querySelector('[name="rows[1][stat_type]"]').value).toBe(
+            "points",
+        );
+        expect(document.activeElement).toBe(
+            newRow.querySelector(".stat-player-select"),
+        );
+        expect(document.querySelectorAll(".remove-row-btn")[0].disabled).toBe(
+            false,
+        );
+        expect(document.querySelectorAll(".remove-row-btn")[1].disabled).toBe(
+            false,
+        );
+    });
+
+    test("removes rows and reindexes the remaining fields", () => {
+        const addButton = document.getElementById("add-stat-row");
+        addButton.click();
+        addButton.click();
+
+        const middleRemoveButton =
+            document.querySelectorAll(".remove-row-btn")[1];
+        middleRemoveButton.click();
+
+        const rows = document.querySelectorAll(".stat-row");
+
+        expect(rows).toHaveLength(2);
+        expect(rows[0].dataset.rowIndex).toBe("0");
+        expect(rows[1].dataset.rowIndex).toBe("1");
+        expect(rows[1].querySelector(".stat-row-label").textContent).toBe(
+            "Player #2",
+        );
+        expect(
+            rows[1].querySelector('[name="rows[1][player_id]"]'),
+        ).not.toBeNull();
+
+        rows[0].querySelector(".remove-row-btn").click();
+
+        expect(document.querySelectorAll(".stat-row")).toHaveLength(1);
+        expect(document.querySelector(".stat-row").dataset.rowIndex).toBe("0");
+        expect(document.querySelector(".stat-row-label").textContent).toBe(
+            "Player #1",
+        );
+        expect(document.querySelector(".remove-row-btn").disabled).toBe(true);
+    });
+});

--- a/js/tests/team_season_form_controller.test.js
+++ b/js/tests/team_season_form_controller.test.js
@@ -10,6 +10,12 @@ describe("team-season-form controller", () => {
     let tinymceInitMock;
     let tinymceRemoveMock;
     let tinymceGetMock;
+    let originalXMLHttpRequest;
+
+    const flush = async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+    };
 
     function getController() {
         return application.getControllerForElementAndIdentifier(
@@ -18,30 +24,98 @@ describe("team-season-form controller", () => {
         );
     }
 
-    beforeEach(() => {
+    function controllerMarkup(options = {}) {
+        const {
+            includePreviewEditor = true,
+            includeRecapEditor = true,
+            includeImageField = true,
+            includeImagePreview = true,
+            includePreviewImageTag = true,
+            includeHeroVariantButton = true,
+            includeUploadButton = true,
+            imageFieldValue = "",
+        } = options;
+
+        return `
+            ${
+                includePreviewEditor
+                    ? '<textarea id="team-season-preview" data-team-season-form-target="previewEditor"></textarea>'
+                    : ""
+            }
+            ${
+                includeRecapEditor
+                    ? '<textarea id="team-season-recap" data-team-season-form-target="recapEditor"></textarea>'
+                    : ""
+            }
+            ${
+                includeImageField
+                    ? `<input id="team-season-image-field" data-team-season-form-target="imageField" value="${imageFieldValue}" />`
+                    : ""
+            }
+            ${
+                includeImagePreview
+                    ? `<div id="team-season-image-preview" data-team-season-form-target="imagePreview" style="display:none;">${
+                          includePreviewImageTag
+                              ? '<img src="" alt="preview">'
+                              : ""
+                      }</div>`
+                    : ""
+            }
+            ${
+                includeHeroVariantButton
+                    ? '<a id="team-season-hero-variant-btn" data-team-season-form-target="heroVariantButton" style="display:none;"></a>'
+                    : ""
+            }
+            ${
+                includeUploadButton
+                    ? '<button id="select-team-season-image" data-team-season-form-target="uploadButton">Select / Upload</button>'
+                    : ""
+            }
+        `;
+    }
+
+    async function mountController(options = {}) {
+        if (application) {
+            application.stop();
+            application = null;
+        }
+
+        document.body.innerHTML = "";
+
         controllerElement = document.createElement("div");
         controllerElement.setAttribute("data-controller", "team-season-form");
         controllerElement.setAttribute(
             "data-team-season-form-existing-image-id-value",
-            "77",
+            options.existingImageIdValue ?? "77",
         );
         controllerElement.setAttribute(
             "data-team-season-form-existing-preview-url-value",
-            "/img/storage/77-hero.jpg",
+            options.existingPreviewUrlValue ?? "/img/storage/77-hero.jpg",
         );
         controllerElement.setAttribute(
             "data-team-season-form-upload-url-value",
-            "/admin/images/upload",
+            options.uploadUrlValue ?? "/admin/images/upload",
         );
-        controllerElement.innerHTML = `
-            <textarea id="team-season-preview" data-team-season-form-target="previewEditor"></textarea>
-            <textarea id="team-season-recap" data-team-season-form-target="recapEditor"></textarea>
-            <input id="team-season-image-field" data-team-season-form-target="imageField" value="" />
-            <div id="team-season-image-preview" data-team-season-form-target="imagePreview" style="display:none;"><img src="" alt="preview"></div>
-            <a id="team-season-hero-variant-btn" data-team-season-form-target="heroVariantButton" style="display:none;"></a>
-            <button id="select-team-season-image" data-team-season-form-target="uploadButton">Select / Upload</button>
-        `;
+        controllerElement.innerHTML = controllerMarkup(options);
         document.body.appendChild(controllerElement);
+
+        application = Application.start();
+        application.register("team-season-form", TeamSeasonFormController);
+
+        await flush();
+
+        return (
+            getController() ||
+            application.controllers.find(
+                (controller) =>
+                    controller.identifier === "team-season-form" &&
+                    controller.element === controllerElement,
+            )
+        );
+    }
+
+    beforeEach(async () => {
+        originalXMLHttpRequest = window.XMLHttpRequest;
 
         tinymceGetMock = jest.fn(() => null);
         tinymceInitMock = jest.fn();
@@ -65,8 +139,7 @@ describe("team-season-form controller", () => {
             }),
         }));
 
-        application = Application.start();
-        application.register("team-season-form", TeamSeasonFormController);
+        await mountController();
     });
 
     afterEach(() => {
@@ -75,8 +148,10 @@ describe("team-season-form controller", () => {
             application = null;
         }
 
+        window.XMLHttpRequest = originalXMLHttpRequest;
         delete window.tinymce;
         delete window.fetch;
+        document.head.querySelector('meta[name="csrfToken"]')?.remove();
         document.body.innerHTML = "";
     });
 
@@ -145,5 +220,319 @@ describe("team-season-form controller", () => {
         document.dispatchEvent(new Event("turbo:before-cache"));
 
         expect(removeMock).toHaveBeenCalled();
+    });
+
+    test("retries TinyMCE init when unavailable and stops at retry cap", () => {
+        const controller = getController();
+        const setTimeoutSpy = jest.spyOn(window, "setTimeout");
+
+        delete window.tinymce;
+        controller.tinyMceRetryCount = 0;
+        controller.initTinyMceWhenReady();
+
+        expect(controller.tinyMceRetryCount).toBe(1);
+        expect(setTimeoutSpy).toHaveBeenCalled();
+
+        controller.tinyMceRetryCount = 20;
+        controller.initTinyMceWhenReady();
+        expect(controller.tinyMceRetryCount).toBe(20);
+        expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+
+        setTimeoutSpy.mockRestore();
+        window.tinymce = {
+            get: tinymceGetMock,
+            init: tinymceInitMock,
+            remove: tinymceRemoveMock,
+        };
+    });
+
+    test("handles missing editor targets and already-initialized editors", async () => {
+        tinymceInitMock.mockClear();
+        await mountController({
+            includePreviewEditor: false,
+            includeRecapEditor: false,
+        });
+        expect(tinymceInitMock).not.toHaveBeenCalled();
+
+        const controller = await mountController();
+        controller.previewEditorTarget.id = "";
+        tinymceGetMock.mockImplementation((editorId) =>
+            editorId === "team-season-recap" ? { id: editorId } : null,
+        );
+        tinymceInitMock.mockClear();
+
+        controller.initTinyMceWhenReady();
+        expect(tinymceInitMock).not.toHaveBeenCalled();
+    });
+
+    test("covers TinyMCE upload handler success, progress, and CSRF header", async () => {
+        const uploadHandler =
+            tinymceInitMock.mock.calls[0][0].images_upload_handler;
+        const progress = jest.fn();
+        const blobInfo = {
+            blob: () => new window.Blob(["x"], { type: "image/jpeg" }),
+            filename: () => "upload.jpg",
+        };
+        const csrf = document.createElement("meta");
+        csrf.name = "csrfToken";
+        csrf.content = "csrf-123";
+        document.head.appendChild(csrf);
+
+        let xhrInstance;
+        class MockXHR {
+            constructor() {
+                this.upload = {};
+                this.status = 0;
+                this.responseText = "";
+                this.open = jest.fn();
+                this.setRequestHeader = jest.fn();
+                this.send = jest.fn(() => {
+                    this.upload.onprogress({
+                        lengthComputable: true,
+                        loaded: 25,
+                        total: 100,
+                    });
+                    this.status = 200;
+                    this.responseText = JSON.stringify({
+                        success: true,
+                        image: { url: "/img/storage/from-handler.jpg" },
+                    });
+                    this.onload();
+                });
+                xhrInstance = this;
+            }
+        }
+
+        window.XMLHttpRequest = MockXHR;
+
+        await expect(uploadHandler(blobInfo, progress)).resolves.toBe(
+            "/img/storage/from-handler.jpg",
+        );
+        expect(progress).toHaveBeenCalledWith(25);
+        expect(xhrInstance.setRequestHeader).toHaveBeenCalledWith(
+            "X-CSRF-Token",
+            "csrf-123",
+        );
+
+        csrf.remove();
+    });
+
+    test("covers TinyMCE upload handler rejection branches", async () => {
+        const uploadHandler =
+            tinymceInitMock.mock.calls[0][0].images_upload_handler;
+        const blobInfo = {
+            blob: () => new window.Blob(["x"], { type: "image/jpeg" }),
+            filename: () => "upload.jpg",
+        };
+
+        const scenarios = [
+            {
+                status: 500,
+                responseText: "{}",
+                expected: "HTTP Error: 500",
+                triggerError: false,
+            },
+            {
+                status: 200,
+                responseText: "{bad json",
+                expected: "Invalid JSON",
+                triggerError: false,
+            },
+            {
+                status: 200,
+                responseText: JSON.stringify({ success: false, error: "nope" }),
+                expected: "nope",
+                triggerError: false,
+            },
+            {
+                status: 200,
+                responseText: JSON.stringify({ success: true, image: {} }),
+                expected: "Upload failed",
+                triggerError: false,
+            },
+            {
+                status: 0,
+                responseText: "{}",
+                expected: "Image upload failed",
+                triggerError: true,
+            },
+        ];
+
+        let scenarioIndex = 0;
+        let lastXhr;
+        class MockXHR {
+            constructor() {
+                this.upload = {};
+                this.open = jest.fn();
+                this.setRequestHeader = jest.fn();
+                this.send = jest.fn(() => {
+                    const scenario = scenarios[scenarioIndex];
+                    this.upload.onprogress({
+                        lengthComputable: false,
+                        loaded: 10,
+                        total: 100,
+                    });
+                    if (scenario.triggerError) {
+                        this.onerror();
+                        return;
+                    }
+                    this.status = scenario.status;
+                    this.responseText = scenario.responseText;
+                    this.onload();
+                });
+                lastXhr = this;
+            }
+        }
+
+        window.XMLHttpRequest = MockXHR;
+
+        for (const scenario of scenarios) {
+            const progress = jest.fn();
+            await expect(uploadHandler(blobInfo, progress)).rejects.toBe(
+                scenario.expected,
+            );
+            expect(progress).not.toHaveBeenCalled();
+            expect(lastXhr.setRequestHeader).not.toHaveBeenCalled();
+            scenarioIndex += 1;
+        }
+    });
+
+    test("returns early on upload guard branches", async () => {
+        const controller = getController();
+
+        window.fetch.mockClear();
+        await controller.uploadSelectedFile({ files: [] });
+        expect(window.fetch).not.toHaveBeenCalled();
+
+        const noFieldController = await mountController({
+            includeImageField: false,
+        });
+        window.fetch.mockClear();
+        await noFieldController.uploadSelectedFile({
+            files: [
+                new window.File(["x"], "season.jpg", { type: "image/jpeg" }),
+            ],
+        });
+        expect(window.fetch).not.toHaveBeenCalled();
+    });
+
+    test("covers upload failure branches and button-missing path", async () => {
+        const alertSpy = jest
+            .spyOn(window, "alert")
+            .mockImplementation(() => {});
+        const errorSpy = jest
+            .spyOn(console, "error")
+            .mockImplementation(() => {});
+
+        const noButtonController = await mountController({
+            includeUploadButton: false,
+        });
+        window.fetch = jest.fn(async () => ({
+            ok: false,
+            json: async () => ({}),
+        }));
+
+        await noButtonController.uploadSelectedFile({
+            files: [
+                new window.File(["x"], "season.jpg", { type: "image/jpeg" }),
+            ],
+        });
+
+        expect(alertSpy).toHaveBeenCalledWith("Upload failed: Upload failed");
+
+        const controller = await mountController();
+        window.fetch = jest.fn(async () => ({
+            ok: true,
+            json: async () => ({ success: false }),
+        }));
+
+        await controller.uploadSelectedFile({
+            files: [
+                new window.File(["x"], "season.jpg", { type: "image/jpeg" }),
+            ],
+        });
+
+        expect(alertSpy).toHaveBeenCalledWith("Upload failed: Upload failed");
+        expect(errorSpy).toHaveBeenCalled();
+
+        alertSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
+
+    test("covers upload URL fallback fields and preview helper branches", async () => {
+        const controller = await mountController({
+            includePreviewImageTag: false,
+        });
+
+        window.fetch = jest.fn(async () => ({
+            ok: true,
+            json: async () => ({
+                success: true,
+                image: { id: 91, url: "", thumbnail_url: "", hero_url: "" },
+            }),
+        }));
+
+        await controller.uploadSelectedFile({
+            files: [
+                new window.File(["x"], "season.jpg", { type: "image/jpeg" }),
+            ],
+        });
+
+        expect(controller.imageFieldTarget.dataset.selectedImageUrl).toBe("");
+        expect(
+            controller.imageFieldTarget.dataset.selectedImageThumbnailUrl,
+        ).toBe("");
+        expect(controller.imageFieldTarget.dataset.selectedImageHeroUrl).toBe(
+            "",
+        );
+
+        controller.imageFieldTarget.value = "not-a-number";
+        controller.updateImagePreview();
+        expect(controller.imagePreviewTarget.style.display).toBe("none");
+
+        expect(controller.withCacheBust("")).toBe("");
+        expect(controller.withCacheBust("/img/storage/pic.jpg")).toContain(
+            "?_ts=",
+        );
+        expect(controller.withCacheBust("/img/storage/pic.jpg?v=1")).toContain(
+            "&_ts=",
+        );
+    });
+
+    test("covers updateHeroVariant guard and hide branch", async () => {
+        const noHeroController = await mountController({
+            includeHeroVariantButton: false,
+        });
+        expect(() => noHeroController.updateHeroVariantButton()).not.toThrow();
+
+        const controller = await mountController();
+        controller.imageFieldTarget.value = "0";
+        controller.updateHeroVariantButton();
+
+        expect(controller.heroVariantButtonTarget.style.display).toBe("none");
+    });
+
+    test("clears retry timer on disconnect", () => {
+        const controller = getController();
+        const clearTimeoutSpy = jest.spyOn(window, "clearTimeout");
+
+        controller.tinyMceRetryTimer = 123;
+        controller.disconnect();
+
+        expect(clearTimeoutSpy).toHaveBeenCalledWith(123);
+        expect(controller.tinyMceRetryTimer).toBeNull();
+
+        clearTimeoutSpy.mockRestore();
+    });
+
+    test("covers disconnect branches and preview guard when targets are absent", async () => {
+        const controller = await mountController({
+            includeImageField: false,
+            includeImagePreview: false,
+            includeUploadButton: false,
+        });
+
+        expect(() => controller.updateImagePreview()).not.toThrow();
+        expect(() => controller.disconnect()).not.toThrow();
     });
 });

--- a/webroot/js/tests/image-retry.test.mjs
+++ b/webroot/js/tests/image-retry.test.mjs
@@ -1,0 +1,108 @@
+import { jest } from "@jest/globals";
+
+const loadModule = async () => import("../image-retry.mjs");
+
+describe("image retry utility", () => {
+    beforeEach(() => {
+        jest.resetModules();
+        document.body.innerHTML = "";
+        delete window.__rhImageRetryInit;
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = "";
+        delete window.__rhImageRetryInit;
+        jest.restoreAllMocks();
+    });
+
+    test("retries a broken serve image and busts picture srcset candidates", async () => {
+        jest.spyOn(Date, "now").mockReturnValue(1111);
+        await loadModule();
+
+        document.body.innerHTML = `
+            <picture>
+                <source
+                    id="srcset-source"
+                    srcset="/images/serve/7 1x, /assets/logo.png 2x"
+                />
+                <img id="serve-image" src="/images/serve/7" alt="broken" />
+            </picture>
+        `;
+
+        const img = document.getElementById("serve-image");
+        img.dispatchEvent(new Event("error"));
+
+        expect(img.dataset.rhRetryAttempted).toBe("1");
+        expect(img.getAttribute("src")).toBe("/images/serve/7?_ts=1111");
+        expect(
+            document.getElementById("srcset-source").getAttribute("srcset"),
+        ).toBe("/images/serve/7?_ts=1111 1x, /assets/logo.png 2x");
+    });
+
+    test("does not retry non-serve urls and only retries each image once", async () => {
+        jest.spyOn(Date, "now").mockReturnValue(2222);
+        await loadModule();
+
+        document.body.innerHTML = `
+            <img id="public-image" src="/img/site/logo.png" alt="public" />
+            <img id="serve-image" src="/images/serve/9" alt="serve" />
+        `;
+
+        const publicImage = document.getElementById("public-image");
+        const serveImage = document.getElementById("serve-image");
+
+        publicImage.dispatchEvent(new Event("error"));
+        expect(publicImage.dataset.rhRetryAttempted).toBeUndefined();
+        expect(publicImage.getAttribute("src")).toBe("/img/site/logo.png");
+
+        serveImage.dispatchEvent(new Event("error"));
+        expect(serveImage.getAttribute("src")).toBe("/images/serve/9?_ts=2222");
+
+        jest.spyOn(Date, "now").mockReturnValue(3333);
+        serveImage.dispatchEvent(new Event("error"));
+        expect(serveImage.getAttribute("src")).toBe("/images/serve/9?_ts=2222");
+    });
+
+    test("retries already-broken images on DOMContentLoaded and turbo load", async () => {
+        jest.spyOn(Date, "now").mockReturnValue(4444);
+        await loadModule();
+
+        const serveImage = document.createElement("img");
+        serveImage.setAttribute("src", "/images/serve/10");
+        Object.defineProperty(serveImage, "complete", {
+            configurable: true,
+            value: true,
+        });
+        Object.defineProperty(serveImage, "naturalWidth", {
+            configurable: true,
+            value: 0,
+        });
+
+        const healthyImage = document.createElement("img");
+        healthyImage.setAttribute("src", "/images/serve/11");
+        Object.defineProperty(healthyImage, "complete", {
+            configurable: true,
+            value: true,
+        });
+        Object.defineProperty(healthyImage, "naturalWidth", {
+            configurable: true,
+            value: 200,
+        });
+
+        document.body.appendChild(serveImage);
+        document.body.appendChild(healthyImage);
+
+        document.dispatchEvent(new Event("DOMContentLoaded"));
+
+        expect(serveImage.getAttribute("src")).toBe(
+            "/images/serve/10?_ts=4444",
+        );
+        expect(healthyImage.getAttribute("src")).toBe("/images/serve/11");
+
+        jest.spyOn(Date, "now").mockReturnValue(5555);
+        document.dispatchEvent(new Event("turbo:load"));
+        expect(serveImage.getAttribute("src")).toBe(
+            "/images/serve/10?_ts=4444",
+        );
+    });
+});


### PR DESCRIPTION
This pull request adds comprehensive branch and edge case test coverage for the `admin-confirm-delete` and `admin-games-index` Stimulus controllers. The new tests ensure that various fallback behaviors, error handling, and edge cases are exercised, improving the reliability and maintainability of these controllers.

**Expanded and improved test coverage for controllers:**

* **`admin-confirm-delete controller` tests:**
  - Added tests for event handling with and without related targets, context preference logic, and fallback behaviors.
  - Covered methods such as `renderAssociated`, `parseAssociated`, `normalizeIds`, `resolveSourceForm`, `resolvePostAction`, `submitSourceForm`, `submitTempForm`, and `buildExtraFields`, ensuring they handle various input types and error scenarios.
  - Added a utility function `getController` to reliably obtain the controller instance in tests.

* **`admin-games-index controller` tests:**
  - Introduced a new test suite to cover branch and edge cases, including missing dependencies, retry logic, disconnect cleanup, and DataTable initialization/destroy fallbacks.
  - Tested form submission logic, bulk action state updates, and handling of missing or detached DOM targets.

These changes significantly increase the robustness of the test suite for both controllers and help guard against regressions in future development.