### PR TITLE
Integrate AdminLTE 4 into admin dashboard layout

### DIFF
--- a/e2e/admin-sidebar-groups.spec.js
+++ b/e2e/admin-sidebar-groups.spec.js
@@ -1,0 +1,85 @@
+import { test, expect } from "@playwright/test";
+import { loginToAdmin } from "./support/auth.js";
+
+test.describe("Admin sidebar groups", () => {
+    test.beforeEach(async ({ page }) => {
+        const loggedIn = await loginToAdmin(page, {
+            waitUntil: "domcontentloaded",
+            timeout: 10000,
+        });
+
+        if (loggedIn) {
+            await page.goto("/admin/sites", {
+                waitUntil: "domcontentloaded",
+                timeout: 10000,
+            });
+        }
+
+        const loginNotice = page
+            .locator("text=You must be logged in to access the admin area.")
+            .first();
+        const blockedFromAdmin =
+            !loggedIn ||
+            (await loginNotice.count()) > 0 ||
+            page.url().includes("/login");
+
+        test.skip(blockedFromAdmin, "Could not log in to the e2e admin account");
+    });
+
+    test("sports and content groups expand from mini-collapsed desktop sidebar", async ({
+        page,
+    }) => {
+        const sidebarToggle = page
+            .locator('a[data-action="click->admin-layout#toggle"]')
+            .first();
+        const body = page.locator("body");
+
+        const sportsToggle = page
+            .locator('button[data-nav-accordion-prefix*="/admin/sports"]')
+            .first();
+        const contentToggle = page
+            .locator('button[data-nav-accordion-prefix*="/admin/blog"]')
+            .first();
+
+        await expect(sportsToggle).toBeVisible();
+        await expect(contentToggle).toBeVisible();
+
+        // 1) Collapse desktop sidebar to emulate the user-reported state.
+        await sidebarToggle.click();
+        await expect(body).toHaveClass(/sidebar-collapse/);
+
+        // 2) Clicking Sports should auto-expand sidebar and open Sports group.
+        await sportsToggle.click();
+        await expect(body).not.toHaveClass(/sidebar-collapse/);
+        await expect(sportsToggle).toHaveAttribute("aria-expanded", "true");
+
+        const sportsPanel = sportsToggle.locator("xpath=following-sibling::ul[1]");
+        await expect(sportsPanel).toBeVisible();
+        await expect(
+            sportsPanel.locator('a[href="/admin/teams"]'),
+        ).toBeVisible();
+
+        // 3) Collapse again, then verify Content follows the same behavior.
+        await sidebarToggle.click();
+        await expect(body).toHaveClass(/sidebar-collapse/);
+
+        await contentToggle.click();
+        await expect(body).not.toHaveClass(/sidebar-collapse/);
+        await expect(contentToggle).toHaveAttribute("aria-expanded", "true");
+
+        const contentPanel = contentToggle.locator("xpath=following-sibling::ul[1]");
+        await expect(contentPanel).toBeVisible();
+        await expect(
+            contentPanel.locator('a[href="/admin/blog-posts"]'),
+        ).toBeVisible();
+    });
+
+    test("sidebar labels use sports wording and do not mention racing", async ({
+        page,
+    }) => {
+        await expect(page.locator("text=SPORTS").first()).toBeVisible();
+        await expect(page.locator("text=Sports").first()).toBeVisible();
+        await expect(page.locator("text=RACING")).toHaveCount(0);
+        await expect(page.locator("text=Sports & Racing")).toHaveCount(0);
+    });
+});

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -42,6 +42,8 @@ module.exports = [
                 FormData: "readonly",
                 setTimeout: "readonly",
                 clearTimeout: "readonly",
+                localStorage: "readonly",
+                MouseEvent: "readonly",
             },
         },
     },
@@ -111,6 +113,10 @@ module.exports = [
     {
         // CommonJS and other script-like module files
         files: ["js/legacy/modules/**/*.cjs", "js/legacy/**/*.cjs"],
+    },
+    {
+        // Jest mock files (CommonJS)
+        files: ["js/__mocks__/**/*.js", "js/__mocks__/**/*.cjs"],
         languageOptions: {
             ecmaVersion: 2022,
             sourceType: "script",
@@ -120,8 +126,6 @@ module.exports = [
                 console: "readonly",
                 module: "readonly",
                 global: "readonly",
-                $: "readonly",
-                jQuery: "readonly",
             },
         },
     },
@@ -168,6 +172,7 @@ module.exports = [
                 URL: "readonly",
                 URLSearchParams: "readonly",
                 fetch: "readonly",
+                localStorage: "readonly",
                 FormData: "readonly",
                 Blob: "readonly",
                 File: "readonly",

--- a/js/__mocks__/@hotwired/turbo.js
+++ b/js/__mocks__/@hotwired/turbo.js
@@ -4,7 +4,7 @@
  * Provides a minimal stub so that modules importing from @hotwired/turbo
  * can be tested under Jest without installing the full package.
  */
-export default {
+const turboMock = {
     start() {},
     visit() {},
     clearCache() {},
@@ -13,3 +13,6 @@ export default {
     connectStreamSource() {},
     disconnectStreamSource() {},
 };
+
+module.exports = turboMock;
+module.exports.default = turboMock;

--- a/js/__mocks__/styleMock.js
+++ b/js/__mocks__/styleMock.js
@@ -1,0 +1,2 @@
+// Mock for CSS imports in Jest (jsdom cannot process CSS files)
+module.exports = {};

--- a/js/controllers/admin_layout_controller.js
+++ b/js/controllers/admin_layout_controller.js
@@ -1,0 +1,116 @@
+import { Controller } from "@hotwired/stimulus";
+
+const STORAGE_KEY = "rh_admin_sidebar_collapsed";
+const DESKTOP_BREAKPOINT = 992;
+
+/**
+ * AdminLTE 4 layout controller.
+ *
+ * Manages the AdminLTE sidebar state across Turbo page visits.
+ *
+ * Desktop (>= lg): toggles `sidebar-collapse` for mini mode.
+ * Mobile (< lg): toggles `sidebar-open` for off-canvas mode.
+ *
+ * State is persisted to `localStorage` under `rh_admin_sidebar_collapsed` so the
+ * desktop sidebar remembers its collapsed/expanded state across full page loads
+ * and Turbo Drive navigations.
+ *
+ * Usage:
+ *   <div data-controller="admin-layout">
+ *     …
+ *     <button data-action="click->admin-layout#toggle">☰</button>
+ *   </div>
+ */
+export default class extends Controller {
+    /**
+     * Called by Stimulus after the element is connected to the DOM.
+     * Runs on every Turbo Drive page visit because the <body> is replaced,
+     * so the controller re-connects and must re-apply the persisted state.
+     */
+    connect() {
+        this.restoreState();
+        document.addEventListener("turbo:load", this._handleTurboLoad, {
+            once: false,
+        });
+        window.addEventListener("resize", this._handleResize, { once: false });
+    }
+
+    disconnect() {
+        document.removeEventListener("turbo:load", this._handleTurboLoad);
+        window.removeEventListener("resize", this._handleResize);
+    }
+
+    /**
+     * Toggle sidebar between expanded and mini-collapsed.
+     * Persists the new state to localStorage.
+     *
+     * @param {Event} event - click event from the toggle button
+     */
+    toggle(event) {
+        event.preventDefault();
+
+        if (this._isMobile()) {
+            document.body.classList.toggle("sidebar-open");
+            return;
+        }
+
+        const isCollapsed = document.body.classList.toggle("sidebar-collapse");
+        this._persist(isCollapsed);
+    }
+
+    /**
+     * Close mobile off-canvas sidebar.
+     * Safe to call on desktop (it is a no-op visual change there).
+     */
+    closeMobile() {
+        document.body.classList.remove("sidebar-open");
+    }
+
+    /**
+     * Read localStorage and apply the correct body class.
+     * Called from `connect()` so it runs on every Turbo visit.
+     */
+    restoreState() {
+        try {
+            const collapsed = localStorage.getItem(STORAGE_KEY) === "1";
+            document.body.classList.toggle("sidebar-collapse", collapsed);
+        } catch {
+            // Ignore errors in restrictive environments (private browsing, etc.)
+        }
+
+        // Turbo/initial render should always start with closed mobile drawer.
+        this.closeMobile();
+    }
+
+    /**
+     * Persist collapsed state.
+     *
+     * @param {boolean} collapsed
+     */
+    _persist(collapsed) {
+        try {
+            localStorage.setItem(STORAGE_KEY, collapsed ? "1" : "0");
+        } catch {
+            // Ignore
+        }
+    }
+
+    /**
+     * Bound turbo:load handler — restores state after each Turbo Drive visit
+     * because Turbo replaces <body>, resetting any dynamically set classes.
+     */
+    _handleTurboLoad = () => {
+        this.restoreState();
+    };
+
+    _handleResize = () => {
+        // Ensure we never carry an open mobile drawer into desktop layout.
+        if (!this._isMobile()) {
+            this.closeMobile();
+        }
+    };
+
+    _isMobile() {
+        return window.innerWidth < DESKTOP_BREAKPOINT;
+    }
+}

--- a/js/controllers/nav_accordion_controller.js
+++ b/js/controllers/nav_accordion_controller.js
@@ -1,5 +1,8 @@
 import { Controller } from "@hotwired/stimulus";
 
+const DESKTOP_BREAKPOINT = 992;
+const SIDEBAR_COLLAPSE_STORAGE_KEY = "rh_admin_sidebar_collapsed";
+
 export default class extends Controller {
     static targets = ["toggle", "panel"];
 
@@ -8,6 +11,8 @@ export default class extends Controller {
     }
 
     toggle(event) {
+        event.preventDefault();
+
         const button = event.currentTarget;
         const panel = this.findPanel(button);
 
@@ -15,8 +20,46 @@ export default class extends Controller {
             return;
         }
 
+        const desktopCollapsed =
+            window.innerWidth >= DESKTOP_BREAKPOINT &&
+            document.body.classList.contains("sidebar-collapse");
+
+        // In AdminLTE mini mode, first click should expand sidebar and reveal
+        // the clicked group instead of "toggling" it invisibly in a narrow rail.
+        if (desktopCollapsed) {
+            document.body.classList.remove("sidebar-collapse");
+
+            try {
+                localStorage.setItem(SIDEBAR_COLLAPSE_STORAGE_KEY, "0");
+            } catch {
+                // Ignore storage failures.
+            }
+
+            this.setExpanded(button, panel, true);
+            this.toggleTargets.forEach((candidate) => {
+                if (candidate === button) {
+                    return;
+                }
+
+                this.setExpanded(candidate, this.findPanel(candidate), false);
+            });
+
+            return;
+        }
+
         const nextState = button.getAttribute("aria-expanded") !== "true";
         this.setExpanded(button, panel, nextState);
+
+        // Keep accordion interaction predictable: opening one group closes siblings.
+        if (nextState) {
+            this.toggleTargets.forEach((candidate) => {
+                if (candidate === button) {
+                    return;
+                }
+
+                this.setExpanded(candidate, this.findPanel(candidate), false);
+            });
+        }
     }
 
     syncToLocation() {
@@ -59,8 +102,12 @@ export default class extends Controller {
             return;
         }
 
+        const parentItem = button.closest(".nav-item");
+        if (parentItem) {
+            parentItem.classList.toggle("menu-open", expanded);
+        }
+
         panel.hidden = !expanded;
-        panel.classList.toggle("d-none", !expanded);
         panel.dataset.navOpen = expanded ? "true" : "false";
     }
 }

--- a/js/legacy/modules/seasons-init.cjs
+++ b/js/legacy/modules/seasons-init.cjs
@@ -1,3 +1,4 @@
+/* global document, console, window */
 /* eslint-disable no-empty */ /* CommonJS seasons init wrapper for Jest tests */
 (function (global) {
     function initSeasons(opts = {}) {

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,10 @@
 import * as Turbo from "@hotwired/turbo";
 import { Application } from "@hotwired/stimulus";
 
+// AdminLTE 4 layout CSS (supplements Bootstrap 5; structural classes only, no JS)
+import "admin-lte/dist/css/adminlte.min.css";
+
+import AdminLayoutController from "./controllers/admin_layout_controller.js";
 import HeroCropController from "./controllers/hero_crop_controller.js";
 import AdminConfirmDeleteController from "./controllers/admin_confirm_delete_controller.js";
 import AdminBulkTableController from "./controllers/admin_bulk_table_controller.js";
@@ -79,6 +83,7 @@ if (!runtimeAlreadyBooted) {
     initTinyMceLoader();
 
     const stimulus = Application.start();
+    stimulus.register("admin-layout", AdminLayoutController);
     stimulus.register("admin-confirm-delete", AdminConfirmDeleteController);
     stimulus.register("admin-bulk-table", AdminBulkTableController);
     stimulus.register("admin-games-index", AdminGamesIndexController);

--- a/js/tests/admin_layout_controller.test.js
+++ b/js/tests/admin_layout_controller.test.js
@@ -1,0 +1,167 @@
+/* global afterEach, beforeEach, describe, expect, test */
+
+import { Application } from "@hotwired/stimulus";
+
+import AdminLayoutController from "../controllers/admin_layout_controller.js";
+
+const STORAGE_KEY = "rh_admin_sidebar_collapsed";
+
+/**
+ * Mount the controller on a <div> inside <body> so connect() fires correctly
+ * via Stimulus's MutationObserver in jsdom.
+ * The controller toggles `sidebar-collapse` on `document.body`, so assertions
+ * always check `document.body.classList`.
+ *
+ * Mirrors the pattern used in nav_accordion_controller.test.js: call
+ * Application.start() in beforeEach so Stimulus's initial scan completes
+ * before the first test assertion runs.
+ */
+
+// ─── Expanded sidebar (no localStorage value) ───────────────────────────────
+describe("admin-layout controller — no persisted state", () => {
+    let application;
+
+    beforeEach(() => {
+        document.body.innerHTML =
+            '<div id="wrapper" data-controller="admin-layout">' +
+            '<button id="btn" data-action="click->admin-layout#toggle">&#9776;</button>' +
+            "</div>";
+        application = Application.start();
+        application.register("admin-layout", AdminLayoutController);
+    });
+
+    afterEach(() => {
+        application.stop();
+        application = null;
+        document.body.innerHTML = "";
+        document.body.classList.remove("sidebar-collapse");
+        localStorage.removeItem(STORAGE_KEY);
+    });
+
+    test("sidebar is expanded when localStorage is empty", () => {
+        expect(document.body.classList.contains("sidebar-collapse")).toBe(
+            false,
+        );
+    });
+
+    test("toggle collapses the sidebar and persists '1' to localStorage", () => {
+        document.getElementById("btn").click();
+        expect(document.body.classList.contains("sidebar-collapse")).toBe(true);
+        expect(localStorage.getItem(STORAGE_KEY)).toBe("1");
+    });
+
+    test("second toggle re-expands the sidebar and persists '0'", () => {
+        const btn = document.getElementById("btn");
+        btn.click();
+        btn.click();
+        expect(document.body.classList.contains("sidebar-collapse")).toBe(
+            false,
+        );
+        expect(localStorage.getItem(STORAGE_KEY)).toBe("0");
+    });
+
+    test("toggle calls event.preventDefault()", () => {
+        const event = new MouseEvent("click", {
+            bubbles: true,
+            cancelable: true,
+        });
+        document.getElementById("btn").dispatchEvent(event);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    test("toggle uses sidebar-open on mobile without mutating desktop collapse state", () => {
+        const originalInnerWidth = window.innerWidth;
+        Object.defineProperty(window, "innerWidth", {
+            configurable: true,
+            writable: true,
+            value: 768,
+        });
+
+        const btn = document.getElementById("btn");
+        btn.click();
+        expect(document.body.classList.contains("sidebar-open")).toBe(true);
+        expect(document.body.classList.contains("sidebar-collapse")).toBe(
+            false,
+        );
+        expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+        btn.click();
+        expect(document.body.classList.contains("sidebar-open")).toBe(false);
+
+        Object.defineProperty(window, "innerWidth", {
+            configurable: true,
+            writable: true,
+            value: originalInnerWidth,
+        });
+    });
+
+    test("turbo:load closes an open mobile sidebar", () => {
+        document.body.classList.add("sidebar-open");
+        document.dispatchEvent(new Event("turbo:load"));
+
+        expect(document.body.classList.contains("sidebar-open")).toBe(false);
+    });
+});
+
+// ─── Pre-collapsed sidebar (localStorage = "1") ─────────────────────────────
+describe("admin-layout controller — pre-collapsed state", () => {
+    let application;
+
+    beforeEach(() => {
+        localStorage.setItem(STORAGE_KEY, "1"); // must be set BEFORE startApp
+        document.body.innerHTML =
+            '<div id="wrapper" data-controller="admin-layout">' +
+            '<button id="btn" data-action="click->admin-layout#toggle">&#9776;</button>' +
+            "</div>";
+        application = Application.start();
+        application.register("admin-layout", AdminLayoutController);
+    });
+
+    afterEach(() => {
+        application.stop();
+        application = null;
+        document.body.innerHTML = "";
+        document.body.classList.remove("sidebar-collapse");
+        localStorage.removeItem(STORAGE_KEY);
+    });
+
+    test("sidebar-collapse is applied on connect when localStorage is '1'", () => {
+        expect(document.body.classList.contains("sidebar-collapse")).toBe(true);
+    });
+
+    test("toggle expands the sidebar from a collapsed state", () => {
+        expect(document.body.classList.contains("sidebar-collapse")).toBe(true);
+        document.getElementById("btn").click();
+        expect(document.body.classList.contains("sidebar-collapse")).toBe(
+            false,
+        );
+        expect(localStorage.getItem(STORAGE_KEY)).toBe("0");
+    });
+});
+
+// ─── Explicit expanded (localStorage = "0") ─────────────────────────────────
+describe("admin-layout controller — explicit expanded state", () => {
+    let application;
+
+    beforeEach(() => {
+        localStorage.setItem(STORAGE_KEY, "0");
+        document.body.innerHTML =
+            '<div id="wrapper" data-controller="admin-layout"></div>';
+        application = Application.start();
+        application.register("admin-layout", AdminLayoutController);
+    });
+
+    afterEach(() => {
+        application.stop();
+        application = null;
+        document.body.innerHTML = "";
+        document.body.classList.remove("sidebar-collapse");
+        localStorage.removeItem(STORAGE_KEY);
+    });
+
+    test("sidebar is expanded when localStorage flag is '0'", () => {
+        expect(document.body.classList.contains("sidebar-collapse")).toBe(
+            false,
+        );
+    });
+});

--- a/js/tests/nav_accordion_controller.test.js
+++ b/js/tests/nav_accordion_controller.test.js
@@ -10,33 +10,41 @@ describe("nav-accordion controller", () => {
     beforeEach(() => {
         document.body.innerHTML = `
             <nav data-controller="nav-accordion">
-                <button
-                    id="games-toggle"
-                    type="button"
-                    data-nav-accordion-target="toggle"
-                    data-nav-accordion-prefix="/games"
-                    data-action="click->nav-accordion#toggle"
-                    aria-controls="games-panel"
-                    aria-expanded="false"
-                >
-                    Games
-                </button>
-                <div id="games-panel" data-nav-accordion-target="panel" hidden class="d-none">
-                    <button
-                        id="streaks-toggle"
-                        type="button"
-                        data-nav-accordion-target="toggle"
-                        data-nav-accordion-prefix="/games/streaks?result=W"
-                        data-action="click->nav-accordion#toggle"
-                        aria-controls="streaks-panel"
-                        aria-expanded="false"
-                    >
-                        Winning
-                    </button>
-                    <div id="streaks-panel" data-nav-accordion-target="panel" hidden class="d-none">
-                        <a href="/games/streaks?result=W">Overall</a>
-                    </div>
-                </div>
+                <ul class="nav sidebar-menu flex-column">
+                    <li id="games-item" class="nav-item">
+                        <button
+                            id="games-toggle"
+                            type="button"
+                            class="nav-link"
+                            data-nav-accordion-target="toggle"
+                            data-nav-accordion-prefix="/games"
+                            data-action="click->nav-accordion#toggle"
+                            aria-controls="games-panel"
+                            aria-expanded="false"
+                        >
+                            Games
+                        </button>
+                        <ul id="games-panel" class="nav nav-treeview" data-nav-accordion-target="panel" hidden>
+                            <li id="streaks-item" class="nav-item">
+                                <button
+                                    id="streaks-toggle"
+                                    type="button"
+                                    class="nav-link"
+                                    data-nav-accordion-target="toggle"
+                                    data-nav-accordion-prefix="/games/streaks?result=W"
+                                    data-action="click->nav-accordion#toggle"
+                                    aria-controls="streaks-panel"
+                                    aria-expanded="false"
+                                >
+                                    Winning
+                                </button>
+                                <ul id="streaks-panel" class="nav nav-treeview" data-nav-accordion-target="panel" hidden>
+                                    <li class="nav-item"><a href="/games/streaks?result=W">Overall</a></li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
             </nav>
         `;
 
@@ -61,45 +69,40 @@ describe("nav-accordion controller", () => {
         const gamesPanel = document.getElementById("games-panel");
         const streaksToggle = document.getElementById("streaks-toggle");
         const streaksPanel = document.getElementById("streaks-panel");
+        const gamesItem = document.getElementById("games-item");
+        const streaksItem = document.getElementById("streaks-item");
 
         expect(gamesToggle.getAttribute("aria-expanded")).toBe("true");
         expect(gamesPanel.hidden).toBe(false);
-        expect(gamesPanel.classList.contains("d-none")).toBe(false);
+        expect(gamesItem.classList.contains("menu-open")).toBe(true);
         expect(streaksToggle.getAttribute("aria-expanded")).toBe("true");
         expect(streaksPanel.hidden).toBe(false);
+        expect(streaksItem.classList.contains("menu-open")).toBe(true);
     });
 
     test("toggles a panel when clicked", async () => {
         window.history.pushState({}, "", "/seasons");
         document.body.innerHTML = `
             <nav data-controller="nav-accordion">
-                <button
-                    id="games-toggle"
-                    type="button"
-                    data-nav-accordion-target="toggle"
-                    data-nav-accordion-prefix="/games"
-                    data-action="click->nav-accordion#toggle"
-                    aria-controls="games-panel"
-                    aria-expanded="false"
-                >
-                    Games
-                </button>
-                <div id="games-panel" data-nav-accordion-target="panel" hidden class="d-none">
-                    <button
-                        id="streaks-toggle"
-                        type="button"
-                        data-nav-accordion-target="toggle"
-                        data-nav-accordion-prefix="/games/streaks?result=W"
-                        data-action="click->nav-accordion#toggle"
-                        aria-controls="streaks-panel"
-                        aria-expanded="false"
-                    >
-                        Winning
-                    </button>
-                    <div id="streaks-panel" data-nav-accordion-target="panel" hidden class="d-none">
-                        <a href="/games/streaks?result=W">Overall</a>
-                    </div>
-                </div>
+                <ul class="nav sidebar-menu flex-column">
+                    <li id="games-item" class="nav-item">
+                        <button
+                            id="games-toggle"
+                            type="button"
+                            class="nav-link"
+                            data-nav-accordion-target="toggle"
+                            data-nav-accordion-prefix="/games"
+                            data-action="click->nav-accordion#toggle"
+                            aria-controls="games-panel"
+                            aria-expanded="false"
+                        >
+                            Games
+                        </button>
+                        <ul id="games-panel" class="nav nav-treeview" data-nav-accordion-target="panel" hidden>
+                            <li class="nav-item"><a href="/games">Index</a></li>
+                        </ul>
+                    </li>
+                </ul>
             </nav>
         `;
 
@@ -110,20 +113,105 @@ describe("nav-accordion controller", () => {
 
         const gamesToggle = document.getElementById("games-toggle");
         const gamesPanel = document.getElementById("games-panel");
+        const gamesItem = document.getElementById("games-item");
 
         expect(gamesToggle.getAttribute("aria-expanded")).toBe("false");
         expect(gamesPanel.hidden).toBe(true);
+        expect(gamesItem.classList.contains("menu-open")).toBe(false);
 
         gamesToggle.click();
 
         expect(gamesToggle.getAttribute("aria-expanded")).toBe("true");
         expect(gamesPanel.hidden).toBe(false);
-        expect(gamesPanel.classList.contains("d-none")).toBe(false);
+        expect(gamesItem.classList.contains("menu-open")).toBe(true);
 
         gamesToggle.click();
 
         expect(gamesToggle.getAttribute("aria-expanded")).toBe("false");
         expect(gamesPanel.hidden).toBe(true);
-        expect(gamesPanel.classList.contains("d-none")).toBe(true);
+        expect(gamesItem.classList.contains("menu-open")).toBe(false);
+    });
+
+    test("expands desktop mini sidebar before opening clicked group", async () => {
+        window.history.pushState({}, "", "/seasons");
+        document.body.innerHTML = `
+            <nav data-controller="nav-accordion">
+                <ul class="nav sidebar-menu flex-column">
+                    <li id="games-item" class="nav-item">
+                        <button
+                            id="games-toggle"
+                            type="button"
+                            class="nav-link"
+                            data-nav-accordion-target="toggle"
+                            data-nav-accordion-prefix="/games"
+                            data-action="click->nav-accordion#toggle"
+                            aria-controls="games-panel"
+                            aria-expanded="false"
+                        >
+                            Games
+                        </button>
+                        <ul id="games-panel" class="nav nav-treeview" data-nav-accordion-target="panel" hidden>
+                            <li class="nav-item"><a href="/games">Index</a></li>
+                        </ul>
+                    </li>
+                    <li id="content-item" class="nav-item">
+                        <button
+                            id="content-toggle"
+                            type="button"
+                            class="nav-link"
+                            data-nav-accordion-target="toggle"
+                            data-nav-accordion-prefix="/blog"
+                            data-action="click->nav-accordion#toggle"
+                            aria-controls="content-panel"
+                            aria-expanded="false"
+                        >
+                            Content
+                        </button>
+                        <ul id="content-panel" class="nav nav-treeview" data-nav-accordion-target="panel" hidden>
+                            <li class="nav-item"><a href="/blog">Blog</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </nav>
+        `;
+
+        document.body.classList.add("sidebar-collapse");
+        localStorage.setItem("rh_admin_sidebar_collapsed", "1");
+
+        const originalInnerWidth = window.innerWidth;
+        Object.defineProperty(window, "innerWidth", {
+            configurable: true,
+            writable: true,
+            value: 1200,
+        });
+
+        application.stop();
+        application = Application.start();
+        application.register("nav-accordion", NavAccordionController);
+        await Promise.resolve();
+
+        const gamesToggle = document.getElementById("games-toggle");
+        const gamesPanel = document.getElementById("games-panel");
+        const gamesItem = document.getElementById("games-item");
+        const contentToggle = document.getElementById("content-toggle");
+        const contentItem = document.getElementById("content-item");
+
+        gamesToggle.click();
+
+        expect(document.body.classList.contains("sidebar-collapse")).toBe(
+            false,
+        );
+        expect(localStorage.getItem("rh_admin_sidebar_collapsed")).toBe("0");
+        expect(gamesToggle.getAttribute("aria-expanded")).toBe("true");
+        expect(gamesPanel.hidden).toBe(false);
+        expect(gamesItem.classList.contains("menu-open")).toBe(true);
+        expect(contentToggle.getAttribute("aria-expanded")).toBe("false");
+        expect(contentItem.classList.contains("menu-open")).toBe(false);
+
+        Object.defineProperty(window, "innerWidth", {
+            configurable: true,
+            writable: true,
+            value: originalInnerWidth,
+        });
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,8 @@
     "": {
       "name": "racerhistory-admin-js",
       "dependencies": {
-        "@hotwired/turbo": "^8.0.23"
+        "@hotwired/turbo": "^8.0.23",
+        "admin-lte": "^4.0.2"
       },
       "devDependencies": {
         "@babel/core": "^7.22.9",
@@ -3948,6 +3949,12 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/admin-lte": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/admin-lte/-/admin-lte-4.0.2.tgz",
+      "integrity": "sha512-eBevnpfJ47uWcM2ui5xCPikB4DcSsx4kOUPSjQUu33BnZJ437OR1twi7idPJ1+3OukHZ1eg+9BnAdjVTHmoedQ==",
+      "license": "MIT"
     },
     "node_modules/agent-base": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -94,13 +94,15 @@
     ],
     "moduleNameMapper": {
       "canvas": "<rootDir>/__mocks__/canvas.js",
-      "^@hotwired/turbo$": "<rootDir>/js/__mocks__/@hotwired/turbo.js"
+      "^@hotwired/turbo$": "<rootDir>/js/__mocks__/@hotwired/turbo.js",
+      "\\.css$": "<rootDir>/js/__mocks__/styleMock.js"
     }
   },
   "overrides": {
     "tar": "^7.5.11"
   },
   "dependencies": {
-    "@hotwired/turbo": "^8.0.23"
+    "@hotwired/turbo": "^8.0.23",
+    "admin-lte": "^4.0.2"
   }
 }

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -6,6 +6,7 @@ namespace App\Controller\Admin;
 use App\Service\DeployAuditService;
 use Cake\Cache\Cache;
 use Cake\Http\Response;
+use Cake\ORM\TableRegistry;
 
 /**
  * Admin Dashboard Controller
@@ -58,8 +59,17 @@ class DashboardController extends AppController
         $service = new DeployAuditService();
         $audit = $service->run();
 
+        $locator = TableRegistry::getTableLocator();
+        $counts = [
+            'sports' => $locator->get('Sports')->find()->count(),
+            'teams' => $locator->get('Teams')->find()->count(),
+            'games' => $locator->get('Games')->find()->count(),
+            'images' => $locator->get('Images')->find()->count(),
+        ];
+
         $this->set('title', 'Admin Dashboard');
         $this->set('audit', $audit);
+        $this->set('counts', $counts);
     }
 
     /**

--- a/templates/Admin/Dashboard/index.php
+++ b/templates/Admin/Dashboard/index.php
@@ -1,12 +1,14 @@
 <?php
 /**
- * Admin Dashboard Index Template
+ * Admin Dashboard Index Template — AdminLTE 4
  *
- * Main landing page for the administrative interface. Provides system health
- * checks (deployment audit) and quick action buttons for common tasks.
+ * Landing page for the administrative interface.
+ * Shows entity count "small boxes" at the top for a quick data overview,
+ * followed by the deployment-audit health accordion and quick-action buttons.
  *
  * @var \App\View\AppView $this
  * @var array{results: array<array{category: string, label: string, status: string, detail: string}>, errors: int, warnings: int, overall: string} $audit
+ * @var array{sports: int, teams: int, games: int, images: int} $counts
  */
 
 $this->assign('title', 'Admin Dashboard');
@@ -29,17 +31,91 @@ $overallLabel = match ($audit['overall']) {
     default => 'Errors found — action required',
 };
 
-// Group results by category
+// Group audit results by category
 $grouped = [];
 foreach ($audit['results'] as $r) {
     $grouped[$r['category']][] = $r;
 }
 ?>
 <div class="admin dashboard">
-    <h1 class="mb-4"><i class="bi bi-speedometer2 me-2"></i>Admin Dashboard</h1>
 
+    <!-- ══════════════════════════════════════════════════════════════
+         ENTITY COUNT SMALL BOXES
+         ══════════════════════════════════════════════════════════════ -->
+    <div class="row" id="admin-small-boxes">
+
+        <!-- Sports -->
+        <div class="col-lg-3 col-md-6 col-sm-6 col-12 mb-3">
+            <div class="small-box bg-info text-white">
+                <div class="inner">
+                    <h3><?= $counts['sports'] ?></h3>
+                    <p>Sports</p>
+                </div>
+                <i class="small-box-icon bi bi-trophy-fill"></i>
+                <a href="<?= $this->Url->build(['prefix' => 'Admin', 'controller' => 'Sports', 'action' => 'index']) ?>"
+                   class="small-box-footer link-light link-underline-opacity-0 link-underline-opacity-50-hover"
+                   data-turbo-frame="admin-content">
+                    Manage Sports <i class="bi bi-arrow-right-circle ms-1"></i>
+                </a>
+            </div>
+        </div>
+
+        <!-- Teams -->
+        <div class="col-lg-3 col-md-6 col-sm-6 col-12 mb-3">
+            <div class="small-box bg-success text-white">
+                <div class="inner">
+                    <h3><?= $counts['teams'] ?></h3>
+                    <p>Teams</p>
+                </div>
+                <i class="small-box-icon bi bi-people-fill"></i>
+                <a href="<?= $this->Url->build(['prefix' => 'Admin', 'controller' => 'Teams', 'action' => 'index']) ?>"
+                   class="small-box-footer link-light link-underline-opacity-0 link-underline-opacity-50-hover"
+                   data-turbo-frame="admin-content">
+                    Manage Teams <i class="bi bi-arrow-right-circle ms-1"></i>
+                </a>
+            </div>
+        </div>
+
+        <!-- Games -->
+        <div class="col-lg-3 col-md-6 col-sm-6 col-12 mb-3">
+            <div class="small-box bg-warning text-white">
+                <div class="inner">
+                    <h3><?= $counts['games'] ?></h3>
+                    <p>Games</p>
+                </div>
+                <i class="small-box-icon bi bi-calendar-event-fill"></i>
+                <a href="<?= $this->Url->build(['prefix' => 'Admin', 'controller' => 'Games', 'action' => 'index']) ?>"
+                   class="small-box-footer link-light link-underline-opacity-0 link-underline-opacity-50-hover"
+                   data-turbo-frame="admin-content">
+                    Manage Games <i class="bi bi-arrow-right-circle ms-1"></i>
+                </a>
+            </div>
+        </div>
+
+        <!-- Images -->
+        <div class="col-lg-3 col-md-6 col-sm-6 col-12 mb-3">
+            <div class="small-box bg-danger text-white">
+                <div class="inner">
+                    <h3><?= $counts['images'] ?></h3>
+                    <p>Images</p>
+                </div>
+                <i class="small-box-icon bi bi-images"></i>
+                <a href="<?= $this->Url->build(['prefix' => 'Admin', 'controller' => 'Images', 'action' => 'index']) ?>"
+                   class="small-box-footer link-light link-underline-opacity-0 link-underline-opacity-50-hover"
+                   data-turbo-frame="admin-content">
+                    Manage Images <i class="bi bi-arrow-right-circle ms-1"></i>
+                </a>
+            </div>
+        </div>
+
+    </div><!-- /.row #admin-small-boxes -->
+
+    <!-- ══════════════════════════════════════════════════════════════
+         QUICK ACTIONS + SYSTEM HEALTH
+         ══════════════════════════════════════════════════════════════ -->
     <div class="row">
-        <!-- Quick Actions -->
+
+        <!-- Quick Actions card -->
         <div class="col-lg-4 mb-4">
             <div class="card h-100">
                 <div class="card-header bg-primary text-white">
@@ -62,12 +138,12 @@ foreach ($audit['results'] as $r) {
                         </a>
 
                         <a href="<?= $this->Url->build(['controller' => 'Images', 'action' => 'bulkUploadForm', 'prefix' => 'Admin']) ?>"
-                           class="btn btn-outline-primary">
+                           class="btn btn-outline-secondary">
                             <i class="bi bi-upload me-2"></i>Upload Images
                         </a>
 
-                        <a href="<?= $this->Url->build(['controller' => 'Blog', 'action' => 'index', 'prefix' => 'Admin']) ?>"
-                           class="btn btn-outline-primary">
+                        <a href="<?= $this->Url->build(['controller' => 'BlogPosts', 'action' => 'index', 'prefix' => 'Admin']) ?>"
+                           class="btn btn-outline-secondary">
                             <i class="bi bi-pencil-square me-2"></i>Manage Blog
                         </a>
                     </div>
@@ -75,7 +151,7 @@ foreach ($audit['results'] as $r) {
             </div>
         </div>
 
-        <!-- System Health -->
+        <!-- System Health card -->
         <div class="col-lg-8 mb-4">
             <div class="card h-100">
                 <div class="card-header d-flex justify-content-between align-items-center">
@@ -94,8 +170,7 @@ foreach ($audit['results'] as $r) {
                     <div class="accordion accordion-flush" id="healthAccordion">
                         <?php $i = 0;
                         foreach ($grouped as $category => $items) :
-                            $i++; ?>
-                            <?php
+                            $i++;
                             $catHasError = false;
                             $catHasWarn = false;
                             foreach ($items as $item) {
@@ -149,5 +224,7 @@ foreach ($audit['results'] as $r) {
                 </div>
             </div>
         </div>
-    </div>
-</div>
+
+    </div><!-- /.row -->
+</div><!-- /.admin.dashboard -->
+

--- a/templates/element/Admin/nav.php
+++ b/templates/element/Admin/nav.php
@@ -1,151 +1,203 @@
 <?php
 /**
- * Admin Navigation Element
+ * Admin Sidebar Navigation Element — AdminLTE 4
  *
- * Bootstrap navbar component for administrative interface navigation.
- * Provides role-based menu items and authentication status display.
+ * Renders the sidebar menu used by `templates/layout/admin.php`.
  *
- * Features:
- * - Bootstrap 5 navbar with responsive design
- * - Primary blue background for admin distinction
- * - Collapsible navigation for mobile devices
- * - Authentication status display with username
- * - Admin-specific navigation links
- * - Logout functionality with prefix handling
+ * Active-link highlighting is driven by PHP (no JS required).
+ * The `nav-accordion` Stimulus controller auto-expands the section group
+ * that matches the current URL so the correct group is always open.
  *
- * Navigation Structure:
- * - Admin Dashboard: Main admin landing page
- * - Manage Users: User administration interface
- * - Authentication Status: Username display with logout
- *
- * Security:
- * - Authentication status checking
- * - Admin prefix URL generation
- * - Proper logout routing to non-admin controller
- *
- * Responsive Design:
- * - Navbar toggler for mobile menu
- * - Bootstrap grid classes for alignment
- * - Collapse behavior for small screens
+ * Structure:
+ *   - Dashboard (top-level direct link)
+ *   - SPORTS group: Sports, Teams, Seasons, Team Seasons,
+ *       Games, Game Types, Opponents, Persons, Places, Sites
+ *   - CONTENT group: Blog Posts, Images
+ *   - ADMINISTRATION group: Users
  *
  * @var \App\View\AppView $this
  */
-// templates/element/Admin/nav.php
+
+$currentController = $this->request->getParam('controller');
+
+/**
+ * Returns the CSS active class string if the current controller is in the provided list.
+ *
+ * @param string ...$controllers
+ * @return string
+ */
+$isActive = function (string ...$controllers) use ($currentController): string {
+    return in_array($currentController, $controllers, true) ? ' active' : '';
+};
+
+$u = fn(array $r): string => $this->Url->build($r);
 ?>
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4" data-turbo-permanent>
-    <div class="container-fluid">
-        <a class="navbar-brand"
-            href="<?= $this->Url->build(['controller' => 'Dashboard', 'action' => 'index', 'prefix' => 'Admin']) ?>"
-            data-turbo-frame="admin-content">Admin</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#adminNavbar"
-            aria-controls="adminNavbar" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="adminNavbar">
-            <ul class="navbar-nav me-auto">
-                <li class="nav-item">
-                    <a class="nav-link"
-                        href="<?= $this->Url->build(['prefix' => 'Admin', 'controller' => 'Users', 'action' => 'index']) ?>"
-                        data-turbo-frame="admin-content">
-                        Users</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link"
-                        href="<?= $this->Url->build(['prefix' => 'Admin', 'controller' => 'Sports', 'action' => 'index']) ?>"
-                        data-turbo-frame="admin-content">
-                        Sports</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link"
-                        href="<?= $this->Url->build(['prefix' => 'Admin', 'controller' => 'Teams', 'action' => 'index']) ?>"
-                        data-turbo-frame="admin-content">
-                        Teams</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link"
-                        href="<?= $this->Url->build(['prefix' => 'Admin', 'controller' => 'Seasons', 'action' => 'index']) ?>"
-                        data-turbo-frame="admin-content">
-                        Seasons</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link"
-                        href="<?= $this->Url->build(['prefix' => 'Admin', 'controller' => 'TeamSeasons', 'action' => 'index']) ?>"
-                        data-turbo-frame="admin-content">
-                        Team Seasons</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link"
-                        href="<?= $this->Url->build(['prefix' => 'Admin', 'controller' => 'Games', 'action' => 'index']) ?>"
-                        data-turbo-frame="admin-content">
-                        Games</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link"
-                        href="<?= $this->Url->build(['prefix' => 'Admin', 'controller' => 'GameTypes', 'action' => 'index']) ?>"
-                        data-turbo-frame="admin-content">
-                        Game Types</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link"
-                        href="<?= $this->Url->build(['prefix' => 'Admin', 'controller' => 'Persons', 'action' => 'index']) ?>"
-                        data-turbo-frame="admin-content">
-                        Persons</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link"
-                        href="<?= $this->Url->build(['prefix' => 'Admin', 'controller' => 'Places', 'action' => 'index']) ?>"
-                        data-turbo-frame="admin-content">
-                        Places</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link"
-                        href="<?= $this->Url->build(['prefix' => 'Admin', 'controller' => 'Sites', 'action' => 'index']) ?>"
-                        data-turbo-frame="admin-content">
-                        Sites</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link"
-                        href="<?= $this->Url->build(['prefix' => 'Admin', 'controller' => 'Opponents', 'action' => 'index']) ?>"
-                        data-turbo-frame="admin-content">
-                        Opponents</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link"
-                        href="<?= $this->Url->build(['prefix' => 'Admin', 'controller' => 'Blog', 'action' => 'index']) ?>"
-                        data-turbo-frame="admin-content">
-                        Blog</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link"
-                        href="<?= $this->Url->build(['prefix' => 'Admin', 'controller' => 'Images', 'action' => 'index']) ?>"
-                        data-turbo-frame="admin-content">
-                        Images</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link"
-                        href="<?= $this->Url->build(['prefix' => 'Admin', 'controller' => 'Images', 'action' => 'bulkUploadForm']) ?>"
-                        data-turbo-frame="admin-content">
-                        <i class="bi bi-upload"></i> Upload Images</a>
-                </li>
-                <!-- Add more admin links here -->
-            </ul>
-            <ul class="navbar-nav ms-auto">
-                <?php if ($this->getRequest()->getAttribute('identity')) : ?>
-                <li class="nav-item d-flex align-items-center">
-                    <span class="navbar-text me-2">Logged in as:
-                        <?= h($this->getRequest()->getAttribute('identity')->get('username')) ?></span>
-                    <a class="nav-link"
-                        href="<?= $this->Url->build(['prefix' => false, 'controller' => 'Users', 'action' => 'logout']) ?>"
-                        data-turbo-frame="_top">Logout</a>
-                </li>
-                <?php else : ?>
-                <li class="nav-item">
-                    <a class="nav-link"
-                        href="<?= $this->Url->build(['prefix' => false, 'controller' => 'Users', 'action' => 'login']) ?>"
-                        data-turbo-frame="_top">Login</a>
-                </li>
-                <?php endif; ?>
-            </ul>
-        </div>
-    </div>
+<nav class="mt-2" data-controller="nav-accordion">
+    <ul class="nav sidebar-menu flex-column" role="menu">
+
+        <!-- ── Dashboard ───────────────────────────────────────────── -->
+        <li class="nav-item">
+            <a class="nav-link<?= $isActive('Dashboard') ?>"
+               href="<?= $u(['prefix' => 'Admin', 'controller' => 'Dashboard', 'action' => 'index']) ?>"
+               data-turbo-frame="admin-content">
+                <i class="nav-icon bi bi-speedometer2"></i>
+                <p>Dashboard</p>
+            </a>
+        </li>
+
+        <!-- ── Sports section ────────────────────────────────────────── -->
+        <li class="nav-header">SPORTS</li>
+
+        <li class="nav-item w-100">
+            <button type="button"
+                    class="nav-link border-0 bg-transparent w-100 text-start<?= $isActive('Sports', 'Teams', 'Seasons', 'TeamSeasons', 'Games', 'GameTypes', 'Opponents', 'Persons', 'Places', 'Sites') ?>"
+                    data-nav-accordion-target="toggle"
+                    data-nav-accordion-prefix="/admin/sports|/admin/teams|/admin/seasons|/admin/team-seasons|/admin/games|/admin/game-types|/admin/opponents|/admin/persons|/admin/places|/admin/sites"
+                    aria-expanded="false"
+                    data-action="click->nav-accordion#toggle">
+                <i class="nav-icon bi bi-trophy"></i>
+                <p>Sports
+                    <i class="nav-arrow bi bi-chevron-down ms-auto"></i>
+                </p>
+            </button>
+            <ul class="nav nav-treeview" data-nav-accordion-target="panel" hidden>
+                    <li class="nav-item">
+                        <a class="nav-link ps-4<?= $isActive('Sports') ?>"
+                           href="<?= $u(['prefix' => 'Admin', 'controller' => 'Sports', 'action' => 'index']) ?>"
+                           data-turbo-frame="admin-content">
+                            <i class="nav-icon bi bi-dash-circle"></i>
+                            <p>Sports</p>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link ps-4<?= $isActive('Teams') ?>"
+                           href="<?= $u(['prefix' => 'Admin', 'controller' => 'Teams', 'action' => 'index']) ?>"
+                           data-turbo-frame="admin-content">
+                            <i class="nav-icon bi bi-dash-circle"></i>
+                            <p>Teams</p>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link ps-4<?= $isActive('Seasons') ?>"
+                           href="<?= $u(['prefix' => 'Admin', 'controller' => 'Seasons', 'action' => 'index']) ?>"
+                           data-turbo-frame="admin-content">
+                            <i class="nav-icon bi bi-dash-circle"></i>
+                            <p>Seasons</p>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link ps-4<?= $isActive('TeamSeasons') ?>"
+                           href="<?= $u(['prefix' => 'Admin', 'controller' => 'TeamSeasons', 'action' => 'index']) ?>"
+                           data-turbo-frame="admin-content">
+                            <i class="nav-icon bi bi-dash-circle"></i>
+                            <p>Team Seasons</p>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link ps-4<?= $isActive('Games') ?>"
+                           href="<?= $u(['prefix' => 'Admin', 'controller' => 'Games', 'action' => 'index']) ?>"
+                           data-turbo-frame="admin-content">
+                            <i class="nav-icon bi bi-dash-circle"></i>
+                            <p>Games</p>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link ps-4<?= $isActive('GameTypes') ?>"
+                           href="<?= $u(['prefix' => 'Admin', 'controller' => 'GameTypes', 'action' => 'index']) ?>"
+                           data-turbo-frame="admin-content">
+                            <i class="nav-icon bi bi-dash-circle"></i>
+                            <p>Game Types</p>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link ps-4<?= $isActive('Opponents') ?>"
+                           href="<?= $u(['prefix' => 'Admin', 'controller' => 'Opponents', 'action' => 'index']) ?>"
+                           data-turbo-frame="admin-content">
+                            <i class="nav-icon bi bi-dash-circle"></i>
+                            <p>Opponents</p>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link ps-4<?= $isActive('Persons') ?>"
+                           href="<?= $u(['prefix' => 'Admin', 'controller' => 'Persons', 'action' => 'index']) ?>"
+                           data-turbo-frame="admin-content">
+                            <i class="nav-icon bi bi-dash-circle"></i>
+                            <p>Persons</p>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link ps-4<?= $isActive('Places') ?>"
+                           href="<?= $u(['prefix' => 'Admin', 'controller' => 'Places', 'action' => 'index']) ?>"
+                           data-turbo-frame="admin-content">
+                            <i class="nav-icon bi bi-dash-circle"></i>
+                            <p>Places</p>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link ps-4<?= $isActive('Sites') ?>"
+                           href="<?= $u(['prefix' => 'Admin', 'controller' => 'Sites', 'action' => 'index']) ?>"
+                           data-turbo-frame="admin-content">
+                            <i class="nav-icon bi bi-dash-circle"></i>
+                            <p>Sites</p>
+                        </a>
+                    </li>
+                </ul>
+        </li>
+
+        <!-- ── Content section ──────────────────────────────────────── -->
+        <li class="nav-header">CONTENT</li>
+
+        <li class="nav-item w-100">
+            <button type="button"
+                    class="nav-link border-0 bg-transparent w-100 text-start<?= $isActive('BlogPosts', 'Images') ?>"
+                    data-nav-accordion-target="toggle"
+                    data-nav-accordion-prefix="/admin/blog|/admin/images"
+                    aria-expanded="false"
+                    data-action="click->nav-accordion#toggle">
+                <i class="nav-icon bi bi-files"></i>
+                <p>Content
+                    <i class="nav-arrow bi bi-chevron-down ms-auto"></i>
+                </p>
+            </button>
+            <ul class="nav nav-treeview" data-nav-accordion-target="panel" hidden>
+                    <li class="nav-item">
+                        <a class="nav-link ps-4<?= $isActive('BlogPosts') ?>"
+                           href="<?= $u(['prefix' => 'Admin', 'controller' => 'BlogPosts', 'action' => 'index']) ?>"
+                           data-turbo-frame="admin-content">
+                            <i class="nav-icon bi bi-pencil-square"></i>
+                            <p>Blog Posts</p>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link ps-4<?= $isActive('Images') ?>"
+                           href="<?= $u(['prefix' => 'Admin', 'controller' => 'Images', 'action' => 'index']) ?>"
+                           data-turbo-frame="admin-content">
+                            <i class="nav-icon bi bi-images"></i>
+                            <p>Images</p>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link ps-4"
+                           href="<?= $u(['prefix' => 'Admin', 'controller' => 'Images', 'action' => 'bulkUploadForm']) ?>"
+                           data-turbo-frame="admin-content">
+                            <i class="nav-icon bi bi-upload"></i>
+                            <p>Upload Images</p>
+                        </a>
+                    </li>
+                </ul>
+        </li>
+
+        <!-- ── Administration section ───────────────────────────────── -->
+        <li class="nav-header">ADMINISTRATION</li>
+
+        <li class="nav-item">
+            <a class="nav-link<?= $isActive('Users') ?>"
+               href="<?= $u(['prefix' => 'Admin', 'controller' => 'Users', 'action' => 'index']) ?>"
+               data-turbo-frame="admin-content">
+                <i class="nav-icon bi bi-people-fill"></i>
+                <p>Users</p>
+            </a>
+        </li>
+
+    </ul>
 </nav>

--- a/templates/layout/admin.php
+++ b/templates/layout/admin.php
@@ -1,23 +1,20 @@
 <?php
 
 /**
- * Admin Layout Template
+ * Admin Layout Template — AdminLTE 4
  *
- * Administrative interface layout providing a clean, functional design for admin operations.
- * Features simplified Bootstrap styling optimized for administrative tasks and data management.
+ * Provides the AdminLTE 4 sidebar layout for all admin views.
  *
- * Features:
- * - Bootstrap 5.3.2 framework for consistent admin UI
- * - Admin navigation element integration
- * - Bootstrap Icons for admin interface elements
- * - Custom cake.css for admin-specific styling
- * - jQuery support for enhanced admin functionality
- * - Container-based layout for admin content
+ * CSS load order:
+ *   1. Bootstrap 5 (CDN) — base component styles
+ *   2. Bootstrap Icons (CDN) — icon font
+ *   3. DataTables Bootstrap 5 skin (CDN) — table plugins
+ *   4. Vite bundle — includes AdminLTE 4 structural CSS + Stimulus controllers
+ *   5. cake.css — project-specific overrides
  *
- * Security:
- * - Admin-only access required
- * - Authentication status integration
- * - CSRF protection for admin forms
+ * AdminLTE JS is intentionally NOT loaded. All layout behaviour (sidebar
+ * toggle, active-link highlighting) is managed by Stimulus controllers
+ * (`admin-layout`, `nav-accordion`) so Turbo Drive page visits work cleanly.
  *
  * @var \App\View\AppView $this
  */
@@ -31,10 +28,10 @@
     <meta name="turbo-refresh-method" content="morph">
     <meta name="turbo-refresh-scroll" content="reset">
     <meta name="csrfToken" content="<?= $this->request->getAttribute('csrfToken') ?>">
-    <title><?= $this->fetch('title') ?></title>
+    <title><?= $this->fetch('title') ?> | RacerHistory Admin</title>
     <?= $this->Html->meta('icon') ?>
     <script>
-        // Admin UI is intentionally light-only; set this before CSS paints.
+        // Admin UI is intentionally light-only; set theme before CSS paints.
         (function () {
             const root = document.documentElement;
             root.setAttribute('data-bs-theme', 'light');
@@ -42,18 +39,18 @@
             root.classList.remove('dark-mode', 'theme-dark');
         })();
     </script>
+    <!-- 1. Bootstrap 5 — required peer for AdminLTE 4 -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
         crossorigin="anonymous">
+    <!-- 2. Bootstrap Icons -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+    <!-- 3. DataTables — Bootstrap 5 skin -->
     <link rel="stylesheet" href="https://cdn.datatables.net/1.13.7/css/dataTables.bootstrap5.min.css">
     <link rel="stylesheet" href="https://cdn.datatables.net/scroller/2.3.0/css/scroller.bootstrap5.min.css">
     <link rel="stylesheet" href="https://cdn.datatables.net/searchbuilder/1.6.0/css/searchBuilder.bootstrap5.min.css">
     <link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.2/css/buttons.bootstrap5.min.css">
     <link rel="stylesheet" href="https://cdn.datatables.net/datetime/1.5.1/css/dataTables.dateTime.min.css">
-    <?= $this->Html->css(['cake']) ?>
-    <?= $this->fetch('meta') ?>
-    <?= $this->fetch('css') ?>
-
+    <!-- 4. Vite bundle (AdminLTE 4 CSS + compiled Stimulus controllers) -->
     <?php if (class_exists('CakeVite\\View\\Helper\\ViteHelper') || class_exists('Josbeir\\Vite\\View\\Helper\\ViteHelper')) : ?>
         <?php if (method_exists($this->Vite, 'element')) : ?>
             <?= $this->Vite->element('js/main.js') ?>
@@ -61,8 +58,11 @@
             <?php $this->Vite->script(['files' => ['js/main.js']]); ?>
         <?php endif; ?>
     <?php endif; ?>
-
-    <!-- jQuery for admin pages (used by DataTables and other plugins) -->
+    <!-- 5. Project-specific overrides -->
+    <?= $this->Html->css(['cake']) ?>
+    <?= $this->fetch('meta') ?>
+    <?= $this->fetch('css') ?>
+    <!-- jQuery + DataTables JS (must load before Bootstrap JS so $.fn.DataTable is available) -->
     <script src="https://code.jquery.com/jquery-3.7.1.min.js" crossorigin="anonymous"></script>
     <script src="https://cdn.datatables.net/1.13.7/js/jquery.dataTables.min.js"></script>
     <script src="https://cdn.datatables.net/1.13.7/js/dataTables.bootstrap5.min.js"></script>
@@ -72,26 +72,121 @@
     <script src="https://cdn.datatables.net/buttons/2.4.2/js/dataTables.buttons.min.js"></script>
     <script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.bootstrap5.min.js"></script>
     <script src="https://cdn.datatables.net/datetime/1.5.1/js/dataTables.dateTime.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous">
-    </script>
+    <!-- Bootstrap 5 JS — required for dropdowns, modals, etc. -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
+        crossorigin="anonymous"></script>
     <?= $this->fetch('script') ?>
 </head>
 
-<body>
-    <?= $this->element('Admin/nav') ?>
-    <main class="main">
-        <div class="container">
-            <turbo-frame id="admin-content" data-turbo-action="advance">
-                <?= $this->Flash->render() ?>
-                <?= $this->fetch('content') ?>
-            </turbo-frame>
-        </div>
-    </main>
-    <footer class="footer bg-light py-3 mt-4">
-        <div class="container text-center">
-            <span class="text-muted">&copy; <?= date('Y') ?> RacerHistory Admin</span>
-        </div>
-    </footer>
+<!--
+    AdminLTE 4 body classes:
+        sidebar-mini      - enables mini collapsed sidebar mode on desktop
+        layout-fixed      - fixed/sticky admin layout rules
+        sidebar-expand-lg - desktop sidebar at >= lg, off-canvas at < lg
+
+    data-controller="admin-layout" wires up the Stimulus controller that:
+        - toggles sidebar-collapse on desktop
+        - toggles sidebar-open on mobile
+        - persists desktop collapsed state in localStorage
+-->
+<body class="sidebar-mini layout-fixed sidebar-expand-lg">
+    <div class="app-wrapper" data-controller="admin-layout">
+
+        <!-- ═══════════════════════════════════════════════════════════
+             TOP NAVIGATION BAR (data-turbo-permanent: preserved across visits)
+             ═══════════════════════════════════════════════════════════ -->
+        <nav class="app-header navbar navbar-expand" id="adminHeader" data-turbo-permanent>
+            <div class="container-fluid">
+                <!-- Left: sidebar toggle + brand -->
+                <ul class="navbar-nav">
+                    <li class="nav-item">
+                        <a class="nav-link" href="#" role="button" aria-label="Toggle sidebar"
+                            data-action="click->admin-layout#toggle">
+                            <i class="bi bi-list fs-4"></i>
+                        </a>
+                    </li>
+                    <li class="nav-item d-none d-md-flex align-items-center ms-2">
+                        <a class="navbar-brand fw-semibold"
+                            href="<?= $this->Url->build(['controller' => 'Dashboard', 'action' => 'index', 'prefix' => 'Admin']) ?>">
+                            RacerHistory Admin
+                        </a>
+                    </li>
+                </ul>
+
+                <!-- Right: identity + logout -->
+                <ul class="navbar-nav ms-auto">
+                    <?php if ($this->getRequest()->getAttribute('identity')) : ?>
+                        <li class="nav-item d-flex align-items-center me-2">
+                            <span class="navbar-text">
+                                <i class="bi bi-person-circle me-1"></i>
+                                <?= h($this->getRequest()->getAttribute('identity')->get('username')) ?>
+                            </span>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link"
+                                href="<?= $this->Url->build(['prefix' => false, 'controller' => 'Users', 'action' => 'logout']) ?>"
+                                data-turbo-frame="_top">
+                                <i class="bi bi-box-arrow-right me-1"></i>Logout
+                            </a>
+                        </li>
+                    <?php else : ?>
+                        <li class="nav-item">
+                            <a class="nav-link"
+                                href="<?= $this->Url->build(['prefix' => false, 'controller' => 'Users', 'action' => 'login']) ?>"
+                                data-turbo-frame="_top">
+                                <i class="bi bi-box-arrow-in-right me-1"></i>Login
+                            </a>
+                        </li>
+                    <?php endif; ?>
+                </ul>
+            </div>
+        </nav>
+
+        <!-- ═══════════════════════════════════════════════════════════
+             SIDEBAR (data-turbo-permanent: preserved across visits)
+             ═══════════════════════════════════════════════════════════ -->
+        <aside class="app-sidebar bg-body-secondary shadow" id="adminSidebar"
+            data-bs-theme="dark" data-turbo-permanent>
+            <!-- Brand logo area -->
+            <div class="sidebar-brand">
+                <a href="<?= $this->Url->build(['controller' => 'Dashboard', 'action' => 'index', 'prefix' => 'Admin']) ?>"
+                    class="brand-link">
+                    <i class="bi bi-mortarboard-fill brand-image me-2 text-warning"></i>
+                    <span class="brand-text fw-semibold">RacerHistory</span>
+                </a>
+            </div>
+
+            <!-- Navigation menu -->
+            <div class="sidebar-wrapper">
+                <?= $this->element('Admin/nav') ?>
+            </div>
+        </aside>
+
+        <div class="sidebar-overlay" data-action="click->admin-layout#closeMobile"></div>
+
+        <!-- ═══════════════════════════════════════════════════════════
+             MAIN CONTENT AREA
+             ═══════════════════════════════════════════════════════════ -->
+        <main class="app-main">
+            <div class="app-content">
+                <div class="container-fluid py-3">
+                    <turbo-frame id="admin-content" data-turbo-action="advance">
+                        <?= $this->Flash->render() ?>
+                        <?= $this->fetch('content') ?>
+                    </turbo-frame>
+                </div>
+            </div>
+        </main>
+
+        <!-- ═══════════════════════════════════════════════════════════
+             FOOTER
+             ═══════════════════════════════════════════════════════════ -->
+        <footer class="app-footer">
+            <strong>&copy; <?= date('Y') ?> RacerHistory Admin</strong>
+            <span class="float-end d-none d-sm-inline text-muted">Powered by CakePHP</span>
+        </footer>
+
+    </div><!-- /.app-wrapper -->
 </body>
 
 </html>

--- a/tests/TestCase/Controller/Admin/DashboardControllerTest.php
+++ b/tests/TestCase/Controller/Admin/DashboardControllerTest.php
@@ -23,6 +23,10 @@ class DashboardControllerTest extends TestCase
      */
     protected array $fixtures = [
         'app.Users',
+        'app.Sports',
+        'app.Teams',
+        'app.Games',
+        'app.Images',
     ];
 
     /**
@@ -198,5 +202,172 @@ class DashboardControllerTest extends TestCase
         $this->get('/admin');
         $this->assertResponseOk();
         $this->assertResponseContains('data-turbo-permanent');
+    }
+
+    // ── AdminLTE 4 layout assertions ──────────────────────────────────────────
+
+    /**
+     * Test the AdminLTE app-wrapper structural element is present.
+     */
+    public function testLayoutContainsAppWrapper(): void
+    {
+        $this->get('/admin');
+        $this->assertResponseOk();
+        $this->assertResponseContains('class="app-wrapper"');
+    }
+
+    /**
+     * Test the AdminLTE sidebar element is present.
+     */
+    public function testLayoutContainsAppSidebar(): void
+    {
+        $this->get('/admin');
+        $this->assertResponseOk();
+        $this->assertResponseContains('class="app-sidebar');
+    }
+
+    /**
+     * Test the AdminLTE header element is present.
+     */
+    public function testLayoutContainsAppHeader(): void
+    {
+        $this->get('/admin');
+        $this->assertResponseOk();
+        $this->assertResponseContains('class="app-header');
+    }
+
+    /**
+     * Test the AdminLTE main content wrapper is present.
+     */
+    public function testLayoutContainsAppMain(): void
+    {
+        $this->get('/admin');
+        $this->assertResponseOk();
+        $this->assertResponseContains('class="app-main"');
+    }
+
+    /**
+     * Test the Stimulus admin-layout controller attribute is wired to the body.
+     */
+    public function testBodyHasAdminLayoutController(): void
+    {
+        $this->get('/admin');
+        $this->assertResponseOk();
+        $this->assertResponseContains('data-controller="admin-layout"');
+    }
+
+    /**
+     * Test the sidebar toggle button is present in the header.
+     */
+    public function testHeaderContainsSidebarToggle(): void
+    {
+        $this->get('/admin');
+        $this->assertResponseOk();
+        $this->assertResponseContains('admin-layout#toggle');
+    }
+
+    /**
+     * Test the body carries AdminLTE layout classes.
+     */
+    public function testBodyCarriesAdminLteClasses(): void
+    {
+        $this->get('/admin');
+        $this->assertResponseOk();
+        $this->assertResponseContains('sidebar-mini');
+        $this->assertResponseContains('layout-fixed');
+        $this->assertResponseContains('sidebar-expand-lg');
+    }
+
+    // ── Dashboard small boxes ────────────────────────────────────────────────
+
+    /**
+     * Test the dashboard renders the small boxes row.
+     */
+    public function testDashboardContainsSmallBoxes(): void
+    {
+        $this->get('/admin');
+        $this->assertResponseOk();
+        $this->assertResponseContains('admin-small-boxes');
+        $this->assertResponseContains('small-box');
+    }
+
+    /**
+     * Test each entity type has a small box entry.
+     */
+    public function testDashboardSmallBoxesContainAllEntities(): void
+    {
+        $this->get('/admin');
+        $this->assertResponseOk();
+        $this->assertResponseContains('Sports');
+        $this->assertResponseContains('Teams');
+        $this->assertResponseContains('Games');
+        $this->assertResponseContains('Images');
+    }
+
+    /**
+     * Test entity counts are numeric values in the response.
+     */
+    public function testDashboardSmallBoxesRenderCounts(): void
+    {
+        $this->get('/admin');
+        $this->assertResponseOk();
+        // The small box <h3> should contain a digit (could be 0 with empty fixtures)
+        $body = (string)$this->_response->getBody();
+        $this->assertMatchesRegularExpression('/<h3>\d+<\/h3>/', $body);
+    }
+
+    /**
+     * Test the sidebar contains grouped navigation sections.
+     */
+    public function testSidebarContainsNavigationSections(): void
+    {
+        $this->get('/admin');
+        $this->assertResponseOk();
+        $this->assertResponseContains('sidebar-menu');
+        $this->assertResponseContains('nav-header');
+    }
+
+    /**
+     * Test sidebar uses the updated sports label and removes racing wording.
+     */
+    public function testSidebarUsesSportsLabelWithoutRacing(): void
+    {
+        $this->get('/admin');
+        $this->assertResponseOk();
+        $this->assertResponseContains('>SPORTS<');
+        $this->assertResponseContains('>Sports');
+        $this->assertResponseNotContains('SPORTS &amp; RACING');
+        $this->assertResponseNotContains('Sports &amp; Racing');
+    }
+
+    /**
+     * Test sidebar groups render AdminLTE nav-treeview panel structure.
+     */
+    public function testSidebarUsesAdminLteNavTreeviewPanels(): void
+    {
+        $this->get('/admin');
+        $this->assertResponseOk();
+        $this->assertResponseContains('class="nav nav-treeview" data-nav-accordion-target="panel" hidden');
+    }
+
+    /**
+     * Test admin sidebar brand icon uses the college-sports mortarboard icon.
+     */
+    public function testSidebarBrandUsesMortarboardIcon(): void
+    {
+        $this->get('/admin');
+        $this->assertResponseOk();
+        $this->assertResponseContains('bi bi-mortarboard-fill');
+        $this->assertResponseNotContains('bi bi-flag-fill brand-image');
+    }
+
+    /**
+     * Test dashboard games info box icon is non-racing themed.
+     */
+    public function testDashboardGamesInfoBoxUsesCalendarIcon(): void
+    {
+        $this->get('/admin');
+        $this->assertResponseOk();
+        $this->assertResponseContains('small-box-icon bi bi-calendar-event-fill');
     }
 }


### PR DESCRIPTION
- Added AdminLTE 4 as a dependency in package.json and package-lock.json.
- Updated DashboardController to fetch entity counts for Sports, Teams, Games, and Images.
- Enhanced the admin dashboard template to display entity counts in small boxes.
- Refactored admin navigation to use AdminLTE 4 sidebar structure with accordion functionality.
- Updated admin layout to include AdminLTE 4 styling and structure.
- Added tests for new layout elements and dashboard features.

