### PR TITLE
Enhance RBAC and admin coverage with targeted tests

### DIFF
--- a/src/Service/SiteOptionsService.php
+++ b/src/Service/SiteOptionsService.php
@@ -249,7 +249,12 @@ class SiteOptionsService
         $current = (bool)$this->getPersistedSetting($optionKey, $default);
         $next = !$current;
 
-        if (!$this->saveSettings([$optionKey => $next])) {
+        // Partial updates must not reset unrelated options back to defaults.
+        // Build a full payload from persisted values, then override the target key.
+        $payload = $this->buildSettingsPayloadFromPersistence();
+        $payload[$optionKey] = $next;
+
+        if (!$this->saveSettings($payload)) {
             return null;
         }
 
@@ -579,6 +584,36 @@ class SiteOptionsService
     {
         $json = json_encode($privileges, JSON_PRETTY_PRINT) ?: '';
 
-        return $this->saveSettings(['role_privileges' => $json]);
+        // Keep all existing option values intact during this targeted update.
+        $payload = $this->buildSettingsPayloadFromPersistence();
+        $payload['role_privileges'] = $json;
+
+        return $this->saveSettings($payload);
+    }
+
+    /**
+     * Build a complete save payload from persisted values, falling back to
+     * configured defaults where no row exists yet.
+     *
+     * @return array<string,mixed>
+     */
+    private function buildSettingsPayloadFromPersistence(): array
+    {
+        $existingRows = $this->loadExistingRows();
+        $payload = [];
+
+        foreach ($this->definitions as $optionKey => $definition) {
+            if (isset($existingRows[$optionKey])) {
+                $payload[$optionKey] = $this->normalizeRuntimeValue(
+                    $existingRows[$optionKey]->value,
+                    $definition,
+                );
+                continue;
+            }
+
+            $payload[$optionKey] = $definition['default'] ?? null;
+        }
+
+        return $payload;
     }
 }

--- a/tests/TestCase/Controller/Admin/SiteOptionsControllerExtraTest.php
+++ b/tests/TestCase/Controller/Admin/SiteOptionsControllerExtraTest.php
@@ -147,6 +147,34 @@ class SiteOptionsControllerExtraTest extends TestCase
     }
 
     /**
+     * Invalid ref should fail fast for edit-sport-configs as well.
+     */
+    public function testEditSportConfigsInvalidSportRefRedirectsToEdit(): void
+    {
+        $this->mockIdentity();
+        $this->enableRetainFlashMessages();
+
+        $this->get('/admin/site-options/edit-sport-configs/not-a-sport');
+
+        $this->assertRedirect('/admin/site-options/edit');
+        $this->assertFlashMessage('Sport not found.');
+    }
+
+    /**
+     * Invalid sport refs should short-circuit delete config action.
+     */
+    public function testDeleteSportConfigInvalidSportRefRedirectsToEdit(): void
+    {
+        $this->mockIdentity();
+        $this->enableRetainFlashMessages();
+
+        $this->delete('/admin/site-options/delete-sport-config/not-a-sport/officials');
+
+        $this->assertRedirect('/admin/site-options/edit');
+        $this->assertFlashMessage('Sport not found.');
+    }
+
+    /**
      * Role-privilege editor should render and persist posted matrix changes.
      */
     public function testEditRolePrivilegesGetAndPost(): void

--- a/tests/TestCase/Controller/Admin/SiteOptionsControllerExtraTest.php
+++ b/tests/TestCase/Controller/Admin/SiteOptionsControllerExtraTest.php
@@ -131,4 +131,51 @@ class SiteOptionsControllerExtraTest extends TestCase
         $this->assertRedirectContains('/admin/site-options/edit-sport-configs/');
         $this->assertFlashMessage('Sport configurations have been reset to defaults.');
     }
+
+    /**
+     * Invalid sport refs should redirect to edit with a helpful flash.
+     */
+    public function testSportsConfigsInvalidSportRefRedirectsToEdit(): void
+    {
+        $this->mockIdentity();
+        $this->enableRetainFlashMessages();
+
+        $this->get('/admin/site-options/sports-configs/not-a-sport');
+
+        $this->assertRedirect('/admin/site-options/edit');
+        $this->assertFlashMessage('Sport not found.');
+    }
+
+    /**
+     * Role-privilege editor should render and persist posted matrix changes.
+     */
+    public function testEditRolePrivilegesGetAndPost(): void
+    {
+        $this->mockIdentity();
+
+        $this->get('/admin/site-options/edit-role-privileges');
+        $this->assertResponseOk();
+        $this->assertResponseContains('Role Privileges');
+
+        $this->enableRetainFlashMessages();
+        $this->post('/admin/site-options/edit-role-privileges', [
+            'privileges' => [
+                'admin' => 'bypass_all, manage_users',
+                'editor' => ['view_any', 'edit_any'],
+                'author' => 'view_own',
+            ],
+            'delete_role' => [
+                'author' => '1',
+            ],
+            'new_role' => 'reviewer',
+            'new_privileges' => 'view_any,comment_moderate',
+        ]);
+
+        $this->assertRedirect('/admin/site-options/edit-role-privileges');
+        $this->assertFlashMessage('Role privileges have been updated.');
+
+        $this->get('/admin/site-options/edit-role-privileges');
+        $this->assertResponseOk();
+        $this->assertResponseContains('Role Privileges');
+    }
 }

--- a/tests/TestCase/Controller/Admin/UsersControllerTest.php
+++ b/tests/TestCase/Controller/Admin/UsersControllerTest.php
@@ -414,4 +414,49 @@ class UsersControllerTest extends TestCase
         $refreshed = $table->get(1);
         $this->assertSame('Direct Update', $refreshed->display_name);
     }
+
+    /**
+     * Edit should persist role_id and accept social links submitted as JSON text.
+     */
+    public function testEditPostPersistsRoleIdAndJsonSocialLinks(): void
+    {
+        $this->loginAsAdmin();
+        $this->enableCsrfToken();
+        $this->enableSecurityToken();
+
+        $this->post('/admin/users/edit/3', [
+            'display_name' => 'JSON Social User',
+            'role_id' => 3,
+            'social_links' => '["https://github.com/aught13","https://twitter.com/racerhistory"]',
+        ]);
+
+        $this->assertRedirect('/admin/users');
+        $this->assertSession('User has been updated successfully.', 'Flash.flash.0.message');
+
+        $updated = $this->getTableLocator()->get('Users')->get(3);
+        $this->assertSame('JSON Social User', (string)$updated->display_name);
+        $this->assertSame(3, (int)$updated->role_id);
+    }
+
+    /**
+     * Empty social links should be normalized without breaking save flow.
+     */
+    public function testEditPostNormalizesEmptySocialLinks(): void
+    {
+        $this->loginAsAdmin();
+        $this->enableCsrfToken();
+        $this->enableSecurityToken();
+
+        $this->post('/admin/users/edit/3', [
+            'display_name' => 'Empty Social User',
+            'social_links' => '',
+        ]);
+
+        $this->assertRedirect('/admin/users');
+        $this->assertSession('User has been updated successfully.', 'Flash.flash.0.message');
+
+        $updated = $this->getTableLocator()->get('Users')->get(3);
+        $this->assertSame('Empty Social User', (string)$updated->display_name);
+        $this->assertNull($updated->social_links);
+    }
 }

--- a/tests/TestCase/Service/ImagesAdminServiceTest.php
+++ b/tests/TestCase/Service/ImagesAdminServiceTest.php
@@ -1,0 +1,135 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\ImageDeleteService;
+use App\Service\ImageEditService;
+use App\Service\ImagesAdminService;
+use App\Service\RbacPermissionService;
+use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class ImagesAdminServiceTest extends TestCase
+{
+    protected array $fixtures = [
+        'app.Images',
+        'app.ImageTags',
+        'app.ImagesImageTags',
+        'app.Users',
+        'app.Roles',
+        'app.Permissions',
+    ];
+
+    private ImagesAdminService $service;
+
+    /**
+     * Initialize service under test with default collaborators.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = new ImagesAdminService(
+            TableRegistry::getTableLocator()->get('Images'),
+            new ImageDeleteService(),
+            new ImageEditService(),
+            new RbacPermissionService(),
+        );
+    }
+
+    /**
+     * Identity objects with applyScope should be honored before RBAC fallback.
+     */
+    public function testGetTotalCountUsesIdentityApplyScopeWhenAvailable(): void
+    {
+        $identity = new class {
+            /**
+             * Restrict test scope to an empty image set.
+             *
+             * @param string $action
+             * @param mixed $query
+             * @return mixed
+             */
+            public function applyScope(string $action, $query)
+            {
+                return $query->where(['Images.id <' => 0]);
+            }
+        };
+
+        $this->assertSame(0, $this->service->getTotalCount($identity));
+    }
+
+    /**
+     * Common tags should parse comma-separated text and trim blanks.
+     */
+    public function testBuildCommonEntityTagsParsesCommonTags(): void
+    {
+        $tags = $this->service->buildCommonEntityTags([
+            'common_tags' => 'alpha, beta, ,gamma ',
+        ]);
+
+        $this->assertSame(['alpha', 'beta', 'gamma'], $tags);
+    }
+
+    /**
+     * Non-admin metadata updates must ignore owner reassignment.
+     */
+    public function testUpdateMetadataIgnoresUserIdForNonAdmin(): void
+    {
+        $bloggerIdentity = [
+            'id' => 3,
+            'role' => 'blogger',
+            'role_id' => 2,
+            'status' => 'active',
+            'active' => true,
+        ];
+
+        $result = $this->service->updateMetadata(2, [
+            'original_name' => 'renamed-by-blogger.png',
+            'user_id' => 1,
+            'photo_credit' => 'Photographer',
+        ], $bloggerIdentity);
+
+        $this->assertTrue($result['success']);
+
+        $image = TableRegistry::getTableLocator()->get('Images')->get(2);
+        $this->assertSame('renamed-by-blogger.png', $image->original_name);
+        $this->assertSame(3, (int)$image->user_id, 'non-admin should not be able to reassign owner');
+    }
+
+    /**
+     * Own-scoped update access should reject attempts to load other users' images.
+     */
+    public function testGetImageByIdThrowsWhenOutsideOwnScope(): void
+    {
+        $bloggerIdentity = [
+            'id' => 3,
+            'role' => 'blogger',
+            'role_id' => 2,
+            'status' => 'active',
+            'active' => true,
+        ];
+
+        $this->expectException(RecordNotFoundException::class);
+        $this->service->getImageById(1, $bloggerIdentity, 'update');
+    }
+
+    /**
+     * Bulk delete should enforce RBAC scope for non-admin identities.
+     */
+    public function testBulkDeleteReturnsZeroForDisallowedIdentity(): void
+    {
+        $bloggerIdentity = [
+            'id' => 3,
+            'role' => 'blogger',
+            'role_id' => 2,
+            'status' => 'active',
+            'active' => true,
+        ];
+
+        $result = $this->service->bulkDelete([1, 2], $bloggerIdentity);
+        $this->assertSame(['deleted' => 0], $result);
+    }
+}

--- a/tests/TestCase/Service/ImagesAdminServiceTest.php
+++ b/tests/TestCase/Service/ImagesAdminServiceTest.php
@@ -74,6 +74,36 @@ class ImagesAdminServiceTest extends TestCase
     }
 
     /**
+     * DataTables payload should include escaped display columns and actions.
+     */
+    public function testBuildIndexDataTablesResponse(): void
+    {
+        $adminIdentity = [
+            'id' => 1,
+            'role' => 'admin',
+            'role_id' => 1,
+            'status' => 'active',
+            'active' => true,
+        ];
+
+        $response = $this->service->buildIndexDataTablesResponse([
+            'draw' => 7,
+            'start' => 0,
+            'length' => 15,
+            'searchValue' => '2',
+            'orderDir' => 'asc',
+            'orderColumn' => 'original_name',
+        ], $adminIdentity);
+
+        $this->assertSame(7, $response['draw']);
+        $this->assertGreaterThanOrEqual(1, $response['total']);
+        $this->assertGreaterThanOrEqual(1, $response['filtered']);
+        $this->assertNotEmpty($response['data']);
+        $this->assertStringContainsString('<img', $response['data'][0]['preview']);
+        $this->assertStringContainsString('Edit', $response['data'][0]['actions']);
+    }
+
+    /**
      * Non-admin metadata updates must ignore owner reassignment.
      */
     public function testUpdateMetadataIgnoresUserIdForNonAdmin(): void
@@ -131,5 +161,45 @@ class ImagesAdminServiceTest extends TestCase
 
         $result = $this->service->bulkDelete([1, 2], $bloggerIdentity);
         $this->assertSame(['deleted' => 0], $result);
+    }
+
+    /**
+     * Admin identities should be able to bulk delete provided IDs.
+     */
+    public function testBulkDeleteDeletesForAdminIdentity(): void
+    {
+        $adminIdentity = [
+            'id' => 1,
+            'role' => 'admin',
+            'role_id' => 1,
+            'status' => 'active',
+            'active' => true,
+        ];
+
+        $result = $this->service->bulkDelete([2], $adminIdentity);
+        $this->assertSame(['deleted' => 1], $result);
+    }
+
+    /**
+     * Edit page data should expose owner label and owner-management capability.
+     */
+    public function testGetEditPageDataForAdminIncludesOwnerMetadata(): void
+    {
+        $adminIdentity = [
+            'id' => 1,
+            'role' => 'admin',
+            'role_id' => 1,
+            'status' => 'active',
+            'active' => true,
+        ];
+
+        $data = $this->service->getEditPageData(1, $adminIdentity);
+
+        $this->assertArrayHasKey('image', $data);
+        $this->assertArrayHasKey('users', $data);
+        $this->assertArrayHasKey('ownerLabel', $data);
+        $this->assertArrayHasKey('canManageImageOwner', $data);
+        $this->assertTrue($data['canManageImageOwner']);
+        $this->assertSame('admin', (string)$data['ownerLabel']);
     }
 }

--- a/tests/TestCase/Service/RbacPermissionServiceTest.php
+++ b/tests/TestCase/Service/RbacPermissionServiceTest.php
@@ -4,10 +4,18 @@ declare(strict_types=1);
 namespace App\Test\TestCase\Service;
 
 use App\Service\RbacPermissionService;
+use Cake\Cache\Cache;
+use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
 class RbacPermissionServiceTest extends TestCase
 {
+    protected array $fixtures = [
+        'app.Users',
+        'app.Roles',
+        'app.Permissions',
+    ];
+
     private RbacPermissionService $service;
 
     /**
@@ -16,6 +24,14 @@ class RbacPermissionServiceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        foreach ([1, 2, 3, 4] as $roleId) {
+            Cache::delete('rbac_permissions_role_' . $roleId);
+        }
+        foreach (['admin', 'blogger', 'editor', 'contributor'] as $roleName) {
+            Cache::delete('rbac_role_id_' . $roleName);
+        }
+
         $this->service = new RbacPermissionService();
     }
 
@@ -65,5 +81,112 @@ class RbacPermissionServiceTest extends TestCase
         $this->assertSame('none', $this->service->normalizeLevelForModel('Games', 'own'));
         $this->assertSame('none', $this->service->normalizeLevelForModel('Games', 'invalid'));
         $this->assertSame('all', $this->service->normalizeLevelForModel('Games', 'all'));
+    }
+
+    /**
+     * Route-level admin access should follow action/controller mappings.
+     */
+    public function testCanAccessAdminRequestAndHasAnyAdminAccess(): void
+    {
+        $inactive = [
+            'id' => 2,
+            'role' => 'user',
+            'role_id' => 4,
+            'status' => 'inactive',
+            'active' => false,
+        ];
+        $contributor = [
+            'id' => 5,
+            'role' => 'contributor',
+            'role_id' => 4,
+            'status' => 'active',
+            'active' => true,
+        ];
+
+        $this->assertFalse($this->service->hasAnyAdminAccess($inactive));
+        $this->assertTrue($this->service->hasAnyAdminAccess($contributor));
+
+        $this->assertFalse($this->service->canAccessAdminRequest($contributor, 'Games', 'index', '/debug-kit/panel'));
+        $this->assertTrue($this->service->canAccessAdminRequest($contributor, 'Dashboard', 'index'));
+        $this->assertTrue($this->service->canAccessAdminRequest($contributor, 'Games', 'index'));
+        $this->assertFalse($this->service->canAccessAdminRequest($contributor, 'Games', 'delete'));
+        $this->assertFalse($this->service->canAccessAdminRequest($contributor, 'Unknown', 'index'));
+        $this->assertFalse($this->service->canAccessAdminRequest($contributor, 'Games', 'unknownAction'));
+    }
+
+    /**
+     * Permission checks should honor create/own/none semantics and ownership.
+     */
+    public function testCanAndScopeQueryHonorPermissionLevels(): void
+    {
+        $blogger = [
+            'id' => 3,
+            'role' => 'blogger',
+            'role_id' => 2,
+            'status' => 'active',
+            'active' => true,
+        ];
+
+        $this->assertTrue($this->service->can($blogger, 'BlogPosts', 'create'));
+        $this->assertTrue($this->service->can($blogger, 'Images', 'update', ['user_id' => 3]));
+        $this->assertFalse($this->service->can($blogger, 'Images', 'update', ['user_id' => 1]));
+        $this->assertFalse($this->service->can($blogger, 'Images', 'delete'));
+
+        $usersScoped = $this->service->scopeQuery(
+            $blogger,
+            'Users',
+            TableRegistry::getTableLocator()->get('Users')->find(),
+            'read',
+            'id',
+        )
+            ->select(['Users.id'])
+            ->enableHydration(false)
+            ->all()
+            ->extract('id')
+            ->toList();
+
+        $this->assertSame([3], array_values(array_map('intval', $usersScoped)));
+
+        $rolesScoped = $this->service->scopeQuery(
+            $blogger,
+            'Roles',
+            TableRegistry::getTableLocator()->get('Roles')->find(),
+            'read',
+            'id',
+        );
+        $this->assertSame(0, $rolesScoped->count());
+    }
+
+    /**
+     * Custom rules and role resolution should use fixture-backed RBAC rows.
+     */
+    public function testCustomRulesAndRoleResolution(): void
+    {
+        $editor = [
+            'id' => 4,
+            'role' => 'editor',
+            'role_id' => 3,
+            'status' => 'active',
+            'active' => true,
+        ];
+        $blogger = [
+            'id' => 3,
+            'role' => 'blogger',
+            'role_id' => 2,
+            'status' => 'active',
+            'active' => true,
+        ];
+
+        $this->assertTrue($this->service->allowsCustomRule($editor, 'BlogPosts', RbacPermissionService::BLOG_RULE_CAN_PIN));
+        $this->assertFalse($this->service->allowsCustomRule($blogger, 'BlogPosts', RbacPermissionService::BLOG_RULE_CAN_PIN));
+
+        $this->assertSame(2, $this->service->getRoleIdForIdentity(['role' => 'author']));
+        $this->assertSame('editor', $this->service->getRoleNameForIdentity(['role_id' => 3]));
+        $this->assertSame('blogger', $this->service->getRoleNameForIdentity(['role' => 'Author']));
+
+        $defaults = $this->service->buildDefaultPermissionPayload('BlogPosts');
+        $this->assertFalse($defaults['can_create']);
+        $this->assertArrayHasKey(RbacPermissionService::BLOG_RULE_CAN_PIN, $defaults['custom_rules']);
+        $this->assertFalse((bool)$defaults['custom_rules'][RbacPermissionService::BLOG_RULE_CAN_PIN]);
     }
 }

--- a/tests/TestCase/Service/SiteOptionsServiceExtraTest.php
+++ b/tests/TestCase/Service/SiteOptionsServiceExtraTest.php
@@ -9,10 +9,18 @@ use App\Service\SiteOptionsService;
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\ORM\Query\SelectQuery;
+use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
 class SiteOptionsServiceExtraTest extends TestCase
 {
+    /**
+     * @var array<string>
+     */
+    protected array $fixtures = [
+        'app.SiteOptions',
+    ];
+
     /**
      * Clean up cache and configuration after each test.
      *
@@ -65,5 +73,105 @@ class SiteOptionsServiceExtraTest extends TestCase
 
         $service = new SiteOptionsService($table, $definitions);
         $this->assertFalse($service->getPersistedSetting('registration', true));
+    }
+
+    /**
+     * Toggle updates should not reset unrelated ad_* settings.
+     */
+    public function testToggleBooleanSettingPreservesAdSettings(): void
+    {
+        $table = TableRegistry::getTableLocator()->get('SiteOptions');
+
+        $this->upsertOption($table, 'registration', 'true');
+        $this->upsertOption($table, 'ad_script', '<script>adsbygoogle</script>');
+        $this->upsertOption($table, 'ad_publisher_id', 'ca-pub-1234567890');
+        $this->upsertOption($table, 'ad_below_nav_html', '<ins class="adsbygoogle"></ins>');
+
+        $definitions = [
+            'registration' => ['label' => 'Registration', 'type' => 'checkbox', 'default' => true],
+            'ad_script' => ['label' => 'Ad Script', 'type' => 'textarea', 'default' => ''],
+            'ad_publisher_id' => ['label' => 'Publisher', 'type' => 'text', 'default' => ''],
+            'ad_below_nav_html' => ['label' => 'Nav Ad', 'type' => 'textarea', 'default' => ''],
+        ];
+
+        $service = new SiteOptionsService($table, $definitions);
+        $this->assertFalse($service->toggleBooleanSetting('registration', true));
+
+        $this->assertSame('false', (string)$table->find()->where(['option_key' => 'registration'])->firstOrFail()->value);
+        $this->assertSame(
+            '<script>adsbygoogle</script>',
+            (string)$table->find()->where(['option_key' => 'ad_script'])->firstOrFail()->value,
+        );
+        $this->assertSame(
+            'ca-pub-1234567890',
+            (string)$table->find()->where(['option_key' => 'ad_publisher_id'])->firstOrFail()->value,
+        );
+        $this->assertSame(
+            '<ins class="adsbygoogle"></ins>',
+            (string)$table->find()->where(['option_key' => 'ad_below_nav_html'])->firstOrFail()->value,
+        );
+    }
+
+    /**
+     * Role-privileges writes should preserve existing ad_* settings.
+     */
+    public function testUpdateRolePrivilegesPreservesAdSettings(): void
+    {
+        $table = TableRegistry::getTableLocator()->get('SiteOptions');
+
+        $this->upsertOption($table, 'registration', 'true');
+        $this->upsertOption($table, 'ad_script', '<script>adsbygoogle</script>');
+        $this->upsertOption($table, 'ad_publisher_id', 'ca-pub-999');
+        $this->upsertOption($table, 'role_privileges', '{"admin":["bypass_all"]}');
+
+        $definitions = [
+            'registration' => ['label' => 'Registration', 'type' => 'checkbox', 'default' => true],
+            'ad_script' => ['label' => 'Ad Script', 'type' => 'textarea', 'default' => ''],
+            'ad_publisher_id' => ['label' => 'Publisher', 'type' => 'text', 'default' => ''],
+            'role_privileges' => ['label' => 'Role Privileges', 'type' => 'textarea', 'default' => ''],
+        ];
+
+        $service = new SiteOptionsService($table, $definitions);
+        $saved = $service->updateRolePrivileges([
+            'admin' => ['bypass_all', 'manage_users'],
+            'editor' => ['view_any'],
+        ]);
+
+        $this->assertTrue($saved);
+        $this->assertSame(
+            '<script>adsbygoogle</script>',
+            (string)$table->find()->where(['option_key' => 'ad_script'])->firstOrFail()->value,
+        );
+        $this->assertSame(
+            'ca-pub-999',
+            (string)$table->find()->where(['option_key' => 'ad_publisher_id'])->firstOrFail()->value,
+        );
+
+        $updatedPrivileges = (string)$table->find()->where(['option_key' => 'role_privileges'])->firstOrFail()->value;
+        $this->assertStringContainsString('manage_users', $updatedPrivileges);
+        $this->assertStringContainsString('editor', $updatedPrivileges);
+    }
+
+    /**
+     * Upsert helper for site option records in integration-style tests.
+     *
+     * @param \App\Model\Table\SiteOptionsTable $table
+     * @param string $key
+     * @param string $value
+     */
+    private function upsertOption(SiteOptionsTable $table, string $key, string $value): void
+    {
+        $row = $table->find()->where(['option_key' => $key])->first();
+        if ($row instanceof SiteOption) {
+            $row->value = $value;
+            $table->saveOrFail($row);
+
+            return;
+        }
+
+        $table->saveOrFail($table->newEntity([
+            'option_key' => $key,
+            'value' => $value,
+        ]));
     }
 }

--- a/tests/TestCase/Service/TeamSeasonAdminServiceTest.php
+++ b/tests/TestCase/Service/TeamSeasonAdminServiceTest.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\TeamSeasonAdminService;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class TeamSeasonAdminServiceTest extends TestCase
+{
+    protected array $fixtures = [
+        'app.TeamSeasons',
+        'app.TeamSeasonRosters',
+        'app.Teams',
+        'app.Seasons',
+        'app.Sports',
+        'app.Games',
+        'app.GameTypes',
+        'app.Opponents',
+        'app.Sites',
+        'app.Places',
+        'app.Persons',
+        'app.Users',
+        'app.Roles',
+        'app.Permissions',
+    ];
+
+    private TeamSeasonAdminService $service;
+
+    /**
+     * Initialize service under test.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new TeamSeasonAdminService();
+    }
+
+    /**
+     * Identifier sanitizer should keep only positive integer-like values.
+     */
+    public function testSanitizeIdentifierList(): void
+    {
+        $actual = $this->service->sanitizeIdentifierList(['', null, '1', 'x', '02', 3, -1]);
+        $this->assertSame([1, 2, 3], $actual);
+    }
+
+    /**
+     * Delete should return false when caller lacks delete scope.
+     */
+    public function testDeleteTeamSeasonReturnsFalseWhenIdentityCannotDelete(): void
+    {
+        $contributorIdentity = [
+            'id' => 5,
+            'role' => 'contributor',
+            'role_id' => 4,
+            'status' => 'active',
+            'active' => true,
+        ];
+
+        $this->assertFalse($this->service->deleteTeamSeason(1, $contributorIdentity));
+    }
+
+    /**
+     * Delete should succeed for admin identities.
+     */
+    public function testDeleteTeamSeasonSucceedsForAdminIdentity(): void
+    {
+        $adminIdentity = [
+            'id' => 1,
+            'role' => 'admin',
+            'role_id' => 1,
+            'status' => 'active',
+            'active' => true,
+        ];
+
+        $this->assertTrue($this->service->deleteTeamSeason(1, $adminIdentity));
+
+        $count = TableRegistry::getTableLocator()->get('TeamSeasons')
+            ->find()
+            ->where(['id' => 1])
+            ->count();
+        $this->assertSame(0, $count);
+    }
+
+    /**
+     * Empty bulk payload should no-op.
+     */
+    public function testBulkDeleteTeamSeasonsReturnsZeroForEmptyInput(): void
+    {
+        $this->assertSame(0, $this->service->bulkDeleteTeamSeasons([]));
+    }
+
+    /**
+     * Bulk delete should no-op when RBAC scope rejects all IDs.
+     */
+    public function testBulkDeleteTeamSeasonsReturnsZeroWhenScopeRejectsIds(): void
+    {
+        $contributorIdentity = [
+            'id' => 5,
+            'role' => 'contributor',
+            'role_id' => 4,
+            'status' => 'active',
+            'active' => true,
+        ];
+
+        $deleted = $this->service->bulkDeleteTeamSeasons(['1', '2'], $contributorIdentity);
+        $this->assertSame(0, $deleted);
+    }
+}

--- a/tests/TestCase/Service/TeamSeasonAdminServiceTest.php
+++ b/tests/TestCase/Service/TeamSeasonAdminServiceTest.php
@@ -108,4 +108,37 @@ class TeamSeasonAdminServiceTest extends TestCase
         $deleted = $this->service->bulkDeleteTeamSeasons(['1', '2'], $contributorIdentity);
         $this->assertSame(0, $deleted);
     }
+
+    /**
+     * Bulk delete should remove allowed IDs for admin identities.
+     */
+    public function testBulkDeleteTeamSeasonsDeletesAllowedIdsForAdmin(): void
+    {
+        $adminIdentity = [
+            'id' => 1,
+            'role' => 'admin',
+            'role_id' => 1,
+            'status' => 'active',
+            'active' => true,
+        ];
+
+        $deleted = $this->service->bulkDeleteTeamSeasons(['1', '2', 'bad'], $adminIdentity);
+        $this->assertSame(2, $deleted);
+    }
+
+    /**
+     * Save-new flow should normalize numeric image IDs for ORM type safety.
+     */
+    public function testSaveNewTeamSeasonNormalizesImageInput(): void
+    {
+        $result = $this->service->saveNewTeamSeason([
+            'team_id' => 1,
+            'season_id' => 1,
+            'semester' => 1,
+            'team_season_image' => '1',
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame(1, (int)$result['teamSeason']->team_season_image);
+    }
 }

--- a/tests/TestCase/View/Helper/SocialLinksHelperTest.php
+++ b/tests/TestCase/View/Helper/SocialLinksHelperTest.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\View\Helper;
+
+use App\View\Helper\SocialLinksHelper;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+
+class SocialLinksHelperTest extends TestCase
+{
+    private SocialLinksHelper $helper;
+
+    /**
+     * Initialize helper under test.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->helper = new SocialLinksHelper(new View());
+    }
+
+    /**
+     * Null input should render no wrapper.
+     */
+    public function testRenderReturnsEmptyStringForNull(): void
+    {
+        $this->assertSame('', $this->helper->render(null));
+    }
+
+    /**
+     * JSON payloads should decode, normalize missing schemes, and map host icons.
+     */
+    public function testRenderDecodesJsonAndMapsKnownIcons(): void
+    {
+        $html = $this->helper->render('["twitter.com/racerhistory","https://github.com/aught13"]');
+
+        $this->assertStringContainsString('social-links', $html);
+        $this->assertStringContainsString('href="https://twitter.com/racerhistory"', $html);
+        $this->assertStringContainsString('bi-twitter', $html);
+        $this->assertStringContainsString('bi-github', $html);
+        $this->assertStringContainsString('@racerhistory', $html);
+        $this->assertStringContainsString('@aught13', $html);
+    }
+
+    /**
+     * Newline payloads should parse and use fallback icon + sanitized labels.
+     */
+    public function testRenderParsesNewlineListAndSanitizesLabel(): void
+    {
+        $html = $this->helper->render("example.com\nhttps://foo.bar/@bad!name\n\n");
+
+        $this->assertStringContainsString('href="https://example.com"', $html);
+        $this->assertStringContainsString('href="https://foo.bar/@bad!name"', $html);
+        $this->assertStringContainsString('bi-link-45deg', $html);
+        $this->assertStringContainsString('@example', $html);
+        $this->assertStringContainsString('@badname', $html);
+    }
+
+    /**
+     * Arrays and scalar fallbacks should skip empty values and still render links.
+     */
+    public function testRenderAcceptsArrayAndScalarFallback(): void
+    {
+        $htmlFromArray = $this->helper->render(['', 'linkedin.com/in/example-user']);
+        $this->assertStringContainsString('bi-linkedin', $htmlFromArray);
+        $this->assertStringContainsString('@example-user', $htmlFromArray);
+
+        $htmlFromScalar = $this->helper->render(12345);
+        $this->assertStringContainsString('href="https://12345"', $htmlFromScalar);
+        $this->assertStringContainsString('@12345', $htmlFromScalar);
+    }
+}


### PR DESCRIPTION

This pull request adds comprehensive test coverage for several admin and service classes, focusing on RBAC (role-based access control), input normalization, and helper utilities. The new and expanded tests ensure that permissions, data handling, and output rendering behave correctly across a variety of user roles and input scenarios.

**New and Expanded Service Tests:**

* **RBAC Permission Handling**
  - [`tests/TestCase/Service/RbacPermissionServiceTest.php`](diffhunk://#diff-5f5ae599b55862b2ee1e6f4d1d269bab69fc2ae37831e8cbc2cc56d37c849bdbR7-R18): Adds fixture-backed tests for permission checks, custom rules, route-level access, and query scoping, ensuring RBAC logic works for different roles and actions. Also clears relevant cache entries in `setUp` for test isolation. [[1]](diffhunk://#diff-5f5ae599b55862b2ee1e6f4d1d269bab69fc2ae37831e8cbc2cc56d37c849bdbR7-R18) [[2]](diffhunk://#diff-5f5ae599b55862b2ee1e6f4d1d269bab69fc2ae37831e8cbc2cc56d37c849bdbR27-R34) [[3]](diffhunk://#diff-5f5ae599b55862b2ee1e6f4d1d269bab69fc2ae37831e8cbc2cc56d37c849bdbR85-R191)

* **Image Admin Service**
  - [`tests/TestCase/Service/ImagesAdminServiceTest.php`](diffhunk://#diff-eea530919c7436627495135db1c72f73b566a5e0f8bd9055681850c4d5b8bde8R1-R205): Introduces tests for tag parsing, DataTables payloads, RBAC-enforced metadata updates, image access, bulk deletes, and admin-specific edit page data.

* **Team Season Admin Service**
  - [`tests/TestCase/Service/TeamSeasonAdminServiceTest.php`](diffhunk://#diff-358e9fc71763c012c9cafc50256810dbf3a489f82a7c9be214b9584389163e6aR1-R144): Adds tests for identifier sanitization, RBAC-protected deletes (single and bulk), and input normalization for new team season creation.

**Controller and Helper Tests:**

* **Admin Site Options and Users Controllers**
  - [`tests/TestCase/Controller/Admin/SiteOptionsControllerExtraTest.php`](diffhunk://#diff-e17fc206ed99c00ed6fc4705b88c7b207e05bc836a43f01eb7138f1c3ad2fd1eR134-R208): Adds tests for invalid sport references, redirecting with flash messages, and role privilege editor flows.
  - [`tests/TestCase/Controller/Admin/UsersControllerTest.php`](diffhunk://#diff-726942a33f1c8393dd26b18ac849625b830b69fbaa9eba5b6f67d2778438113aR417-R461): Adds tests to verify that `role_id` and JSON-formatted social links are persisted, and that empty social links are normalized on user edit.

* **Social Links Helper**
  - [`tests/TestCase/View/Helper/SocialLinksHelperTest.php`](diffhunk://#diff-0e728f0d21c10404b3a0fbe1461dc4bbccd0a499a7250a8b1907ed3cb4d64323R1-R73): Adds tests to ensure the helper correctly parses and renders social links from various input formats, normalizes URLs, maps icons, and sanitizes labels.
