### PR TITLE
Restore admin redirect flow and ad lifecycle handling

### DIFF
--- a/src/Service/GameViewService.php
+++ b/src/Service/GameViewService.php
@@ -5,6 +5,7 @@ namespace App\Service;
 
 use App\Model\Entity\Game;
 use App\Model\Entity\TeamSeason;
+use Cake\ORM\TableRegistry;
 
 /**
  * GameViewService
@@ -51,10 +52,15 @@ class GameViewService
         /** @var \App\Model\Entity\Game $game */
         $game = $this->gameService->getGameWithAssociations($gameId);
 
+        $previousGame = $this->resolveAdjacentGame($game, 'previous');
+        $nextGame = $this->resolveAdjacentGame($game, 'next');
+
         $eav = $this->gameEavUi->mapLegacyKeys($this->gameService->loadGameEavValues($gameId));
 
         $viewData = [
             'game' => $game,
+            'previousGame' => $previousGame,
+            'nextGame' => $nextGame,
             'eav' => $eav,
 
             'teamBoxStats' => [],
@@ -97,6 +103,37 @@ class GameViewService
         $viewData['sportName'] = $sportName;
 
         return $viewData;
+    }
+
+    /**
+     * @param \App\Model\Entity\Game $game
+     * @param 'previous'|'next' $direction
+     * @return \App\Model\Entity\Game|null
+     */
+    private function resolveAdjacentGame(object $game, string $direction): ?object
+    {
+        $teamSeason = $game->get('team_season');
+        $teamSeasonId = $game->team_season_id ?? ($teamSeason instanceof TeamSeason ? $teamSeason->id : null);
+        if ($teamSeasonId === null || $game->game_date === null) {
+            return null;
+        }
+
+        $gamesTable = TableRegistry::getTableLocator()->get('Games');
+        $query = $gamesTable->find()
+            ->where(['Games.team_season_id' => $teamSeasonId])
+            ->where(['Games.id !=' => $game->id]);
+
+        if ($direction === 'previous') {
+            $query->where(['Games.game_date <' => $game->game_date])
+                ->orderByDesc('Games.game_date');
+        } else {
+            $query->where(['Games.game_date >' => $game->game_date])
+                ->orderByAsc('Games.game_date');
+        }
+
+        $adjacent = $query->first();
+
+        return $adjacent instanceof Game ? $adjacent : null;
     }
 
     /**

--- a/src/Service/SeasonViewService.php
+++ b/src/Service/SeasonViewService.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Model\Entity\TeamSeason;
+use Cake\ORM\TableRegistry;
 use Throwable;
 
 /**
@@ -13,6 +15,7 @@ use Throwable;
 class SeasonViewService
 {
     private TeamSeasonService $teamSeasonService;
+    private TeamSportContextService $teamSportContextService;
     private ImageTagService $imageTagService;
     private StatsService $statsService;
     private BlogPostService $blogPostService;
@@ -36,6 +39,7 @@ class SeasonViewService
         ?TeamSeasonRosterService $teamSeasonRosterService = null,
     ) {
         $this->teamSeasonService = $teamSeasonService ?? new TeamSeasonService();
+        $this->teamSportContextService = new TeamSportContextService();
         $this->imageTagService = $imageTagService ?? new ImageTagService();
         $this->statsService = $statsService ?? new StatsService();
         $this->blogPostService = $blogPostService ?? new BlogPostService();
@@ -55,6 +59,9 @@ class SeasonViewService
         if (!$teamSeason) {
             return ['teamSeason' => null];
         }
+
+        $previousTeamSeason = $this->resolveAdjacentTeamSeason($teamSeason, 'previous');
+        $nextTeamSeason = $this->resolveAdjacentTeamSeason($teamSeason, 'next');
 
         $images = $this->imageTagService->getImagesForTeamSeason($teamSeasonId, 24);
         $games = $this->gameService->getGamesByTeamSeason($teamSeasonId, 'ASC');
@@ -89,6 +96,8 @@ class SeasonViewService
 
         return [
             'teamSeason' => $teamSeason,
+            'previousTeamSeason' => $previousTeamSeason,
+            'nextTeamSeason' => $nextTeamSeason,
             'images' => $images,
             'games' => $games,
             'roster' => $roster,
@@ -100,6 +109,48 @@ class SeasonViewService
             'reviewPosts' => $categorized['review'],
             'otherPosts' => $categorized['other'],
         ];
+    }
+
+    /**
+     * @param \App\Model\Entity\TeamSeason $teamSeason
+     * @param 'previous'|'next' $direction
+     * @return \App\Model\Entity\TeamSeason|null
+     */
+    private function resolveAdjacentTeamSeason(object $teamSeason, string $direction): ?object
+    {
+        $team = $teamSeason->team ?? null;
+        $sportKey = $this->teamSportContextService->resolveSportKeyFromTeam($team);
+        $seasonEnd = (int)($teamSeason->season->end ?? 0);
+
+        if ($sportKey === null || $seasonEnd <= 0) {
+            return null;
+        }
+
+        $teamSeasonsTable = TableRegistry::getTableLocator()->get('TeamSeasons');
+        $query = $teamSeasonsTable->find()
+            ->contain(['Teams', 'Seasons'])
+            ->matching('Teams', function ($teamsQuery) use ($sportKey) {
+                return $teamsQuery->where([
+                    'OR' => [
+                        ['Teams.sport_key' => $sportKey],
+                        ['Teams.sport_key IS' => null],
+                    ],
+                ]);
+            })
+            ->matching('Seasons', function ($seasonsQuery) use ($seasonEnd, $direction) {
+                if ($direction === 'previous') {
+                    return $seasonsQuery->where(['Seasons.end <' => $seasonEnd]);
+                }
+
+                return $seasonsQuery->where(['Seasons.end >' => $seasonEnd]);
+            })
+            ->where(['TeamSeasons.id !=' => $teamSeason->id]);
+
+        $query->orderBy($direction === 'previous' ? ['Seasons.end' => 'DESC'] : ['Seasons.end' => 'ASC']);
+
+        $adjacent = $query->first();
+
+        return $adjacent instanceof TeamSeason ? $adjacent : null;
     }
 
     /**

--- a/templates/Admin/TeamSeasons/add.php
+++ b/templates/Admin/TeamSeasons/add.php
@@ -220,40 +220,6 @@ $this->assign('title', 'Add Team Season'); ?>
                         <div class="form-text">Upload an image; its numeric ID will be stored.</div>
                     </div>
 
-                    <div class="mb-3">
-                        <label for="team-season-preview" class="form-label">Season Preview</label>
-                        <?= $this->Form->control('team_season_preview', [
-                            'type' => 'textarea',
-                            'class' => 'form-control',
-                            'label' => false,
-                            'id' => 'team-season-preview',
-                            'rows' => 8,
-                            'placeholder' => 'Preview text for the upcoming season...',
-                            'data-team-season-form-target' => 'previewEditor',
-                            'templates' => [
-                                'textarea' => '<textarea name="{{name}}"{{attrs}}>{{value}}</textarea>',
-                            ],
-                        ]) ?>
-                        <div class="form-text">Pre-season preview or expectations. Rich text supported.</div>
-                    </div>
-
-                    <div class="mb-3">
-                        <label for="team-season-recap" class="form-label">Season Recap</label>
-                        <?= $this->Form->control('team_season_recap', [
-                            'type' => 'textarea',
-                            'class' => 'form-control',
-                            'label' => false,
-                            'id' => 'team-season-recap',
-                            'rows' => 8,
-                            'placeholder' => 'Summary of the completed season...',
-                            'data-team-season-form-target' => 'recapEditor',
-                            'templates' => [
-                                'textarea' => '<textarea name="{{name}}"{{attrs}}>{{value}}</textarea>',
-                            ],
-                        ]) ?>
-                        <div class="form-text">Post-season recap or summary. Rich text supported.</div>
-                    </div>
-
                     <div class="d-flex gap-2">
                         <?= $this->Form->button(__('Save Team Season'), [
                             'type' => 'submit',
@@ -286,14 +252,6 @@ $this->assign('title', 'Add Team Season'); ?>
                     <p class="small text-muted">
                         League fields are optional but help track competitive context and results.
                     </p>
-
-                    <h5>Text Fields</h5>
-                    <ul class="small text-muted">
-                        <li>Preview - Pre-season expectations</li>
-                        <li>Recap - Post-season summary</li>
-                        <li>Notes - General information</li>
-                    </ul>
-
                     <h5>Tips</h5>
                     <ul class="small text-muted">
                         <li>Use consistent league naming</li>

--- a/templates/Admin/TeamSeasons/edit.php
+++ b/templates/Admin/TeamSeasons/edit.php
@@ -209,38 +209,6 @@ $initialPreviewUrl = $initialImageId !== '' ? $this->ImageServe->url((int)$initi
                         </div>
                     </div>
 
-                    <div class="mb-3">
-                        <label for="team-season-preview" class="form-label">Season Preview</label>
-                        <?= $this->Form->control('team_season_preview', [
-                            'type' => 'textarea',
-                            'class' => 'form-control',
-                            'label' => false,
-                            'id' => 'team-season-preview',
-                            'rows' => 8,
-                            'data-team-season-form-target' => 'previewEditor',
-                            'templates' => [
-                                'textarea' => '<textarea name="{{name}}"{{attrs}}>{{value}}</textarea>',
-                            ],
-                        ]) ?>
-                        <div class="form-text">Pre-season preview or expectations. Rich text supported.</div>
-                    </div>
-
-                    <div class="mb-3">
-                        <label for="team-season-recap" class="form-label">Season Recap</label>
-                        <?= $this->Form->control('team_season_recap', [
-                            'type' => 'textarea',
-                            'class' => 'form-control',
-                            'label' => false,
-                            'id' => 'team-season-recap',
-                            'rows' => 8,
-                            'data-team-season-form-target' => 'recapEditor',
-                            'templates' => [
-                                'textarea' => '<textarea name="{{name}}"{{attrs}}>{{value}}</textarea>',
-                            ],
-                        ]) ?>
-                        <div class="form-text">Post-season recap or summary. Rich text supported.</div>
-                    </div>
-
                     <div class="d-flex gap-2">
                         <?= $this->Form->button(__('Update Team Season'), [
                             'type' => 'submit',

--- a/templates/Games/view.php
+++ b/templates/Games/view.php
@@ -100,6 +100,25 @@ $this->start('css'); ?>
 
     <div class="game-hero card shadow-sm mb-4">
         <div class="card-body">
+            <?php if (isset($previousGame) || isset($nextGame)) : ?>
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <?php if (isset($previousGame)) : ?>
+                        <a href="<?= $this->Url->build(['controller' => 'Games', 'action' => 'view', $previousGame->id]) ?>"
+                            class="btn btn-outline-secondary btn-sm" title="Previous Game: <?= h($previousGame->opponent->opponent_name ?? 'Opponent') ?>">
+                            <i class="bi bi-chevron-left"></i> <?= h($previousGame->game_date?->format('M j, Y') ?? '') ?>
+                        </a>
+                    <?php else : ?>
+                        <span></span>
+                    <?php endif; ?>
+
+                    <?php if (isset($nextGame)) : ?>
+                        <a href="<?= $this->Url->build(['controller' => 'Games', 'action' => 'view', $nextGame->id]) ?>"
+                            class="btn btn-outline-secondary btn-sm" title="Next Game: <?= h($nextGame->opponent->opponent_name ?? 'Opponent') ?>">
+                            <?= h($nextGame->game_date?->format('M j, Y') ?? '') ?> <i class="bi bi-chevron-right"></i>
+                        </a>
+                    <?php endif; ?>
+                </div>
+            <?php endif; ?>
             <div class="row align-items-center g-3">
                 <div class="col-lg-5 text-center text-lg-start">
                     <div class="game-scoreline">

--- a/templates/Seasons/view.php
+++ b/templates/Seasons/view.php
@@ -179,6 +179,25 @@ $this->start('css'); ?>
 
     <div class="season-hero card shadow-sm mb-4">
         <div class="card-body">
+            <?php if (isset($previousTeamSeason) || isset($nextTeamSeason)) : ?>
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <?php if (isset($previousTeamSeason)) : ?>
+                        <a href="<?= $this->Url->build(['controller' => 'Seasons', 'action' => 'view', $previousTeamSeason->id]) ?>"
+                            class="btn btn-outline-secondary btn-sm" title="Previous Season: <?= h($previousTeamSeason->season->start . '-' . $previousTeamSeason->season->end) ?>">
+                            <i class="bi bi-chevron-left"></i> <?= h($previousTeamSeason->season->start . '-' . $previousTeamSeason->season->end) ?>
+                        </a>
+                    <?php else : ?>
+                        <span></span>
+                    <?php endif; ?>
+
+                    <?php if (isset($nextTeamSeason)) : ?>
+                        <a href="<?= $this->Url->build(['controller' => 'Seasons', 'action' => 'view', $nextTeamSeason->id]) ?>"
+                            class="btn btn-outline-secondary btn-sm" title="Next Season: <?= h($nextTeamSeason->season->start . '-' . $nextTeamSeason->season->end) ?>">
+                            <?= h($nextTeamSeason->season->start . '-' . $nextTeamSeason->season->end) ?> <i class="bi bi-chevron-right"></i>
+                        </a>
+                    <?php endif; ?>
+                </div>
+            <?php endif; ?>
             <div class="d-flex flex-column flex-lg-row align-items-start align-items-lg-center justify-content-between gap-3">
                 <div class="season-hero-stats d-flex flex-wrap gap-3">
                     <h1 class="display-6 mb-2">

--- a/templates/element/Layout/admin_shell.php
+++ b/templates/element/Layout/admin_shell.php
@@ -80,7 +80,7 @@
     <main class="app-main">
         <div class="app-content">
             <div class="container-fluid py-3">
-                <turbo-frame id="admin-content" data-turbo-action="advance">
+                <turbo-frame id="admin-content" target="_top" data-turbo-action="advance">
                     <?= $flash ?>
                     <?= $content ?>
                 </turbo-frame>

--- a/tests/TestCase/Controller/Admin/AppControllerTest.php
+++ b/tests/TestCase/Controller/Admin/AppControllerTest.php
@@ -56,6 +56,20 @@ class AppControllerTest extends TestCase
     }
 
     /**
+     * Test admin content frame targets the top-level document so redirects recover on login.
+     *
+     * @return void
+     */
+    public function testAdminContentFrameTargetsTopLevel(): void
+    {
+        $this->mockIdentity();
+
+        $this->get('/admin');
+        $this->assertResponseOk();
+        $this->assertResponseContains('turbo-frame id="admin-content" target="_top"');
+    }
+
+    /**
      * Test access to admin area without authentication redirects to login
      *
      * @return void

--- a/tests/TestCase/Controller/Admin/TeamSeasonsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/TeamSeasonsControllerTest.php
@@ -151,9 +151,8 @@ class TeamSeasonsControllerTest extends TestCase
         $this->assertResponseContains('data-controller="team-season-form"');
         $this->assertResponseContains('hidden-team-form');
         $this->assertResponseContains('hidden-season-form');
-        // Rich text editors textareas present
-        $this->assertResponseContains('team-season-preview');
-        $this->assertResponseContains('team-season-recap');
+        $this->assertResponseNotContains('team-season-preview');
+        $this->assertResponseNotContains('team-season-recap');
     }
 
     /**
@@ -426,6 +425,24 @@ class TeamSeasonsControllerTest extends TestCase
         $this->assertResponseContains('bi-chevron-left', 'Previous button icon should be present');
         $this->assertResponseContains('bi-chevron-right', 'Next button icon should be present');
         $this->assertResponseContains('2025-2026', 'Should show next season year range');
+    }
+
+    /**
+     * Test add/edit forms do not include removed preview/recap fields.
+     */
+    public function testAddAndEditFormsDoNotExposePreviewOrRecapFields(): void
+    {
+        $this->mockIdentity();
+
+        $this->get('/admin/team-seasons/add');
+        $this->assertResponseOk();
+        $this->assertResponseNotContains('team_season_preview');
+        $this->assertResponseNotContains('team_season_recap');
+
+        $this->get('/admin/team-seasons/edit/1');
+        $this->assertResponseOk();
+        $this->assertResponseNotContains('team_season_preview');
+        $this->assertResponseNotContains('team_season_recap');
     }
 
     /**

--- a/tests/TestCase/Controller/GamesControllerTest.php
+++ b/tests/TestCase/Controller/GamesControllerTest.php
@@ -115,6 +115,23 @@ class GamesControllerTest extends TestCase
     }
 
     /**
+     * Tests public game view includes previous/next navigation within the same team season.
+     */
+    public function testViewIncludesPreviousAndNextGameNavigation(): void
+    {
+        $this->get('/games/2');
+        $this->assertResponseOk();
+
+        $previousGame = $this->viewVariable('previousGame');
+        $this->assertNotNull($previousGame);
+        $this->assertSame(1, (int)$previousGame->id);
+
+        $nextGame = $this->viewVariable('nextGame');
+        $this->assertNotNull($nextGame);
+        $this->assertSame(3, (int)$nextGame->id);
+    }
+
+    /**
      * Tests stats frame.
      */
     public function testStatsFrame(): void

--- a/tests/TestCase/Controller/SeasonsControllerTest.php
+++ b/tests/TestCase/Controller/SeasonsControllerTest.php
@@ -144,6 +144,42 @@ class SeasonsControllerTest extends TestCase
     }
 
     /**
+     * Tests public season view includes previous/next team-season navigation.
+     */
+    public function testViewIncludesPreviousAndNextTeamSeasonNavigation(): void
+    {
+        $seasonsTable = $this->getTableLocator()->get('Seasons');
+        $teamSeasonsTable = $this->getTableLocator()->get('TeamSeasons');
+
+        $previousSeason = $seasonsTable->newEntity(['start' => 2021, 'end' => 2022]);
+        $nextSeason = $seasonsTable->newEntity(['start' => 2025, 'end' => 2026]);
+        $seasonsTable->saveOrFail($previousSeason);
+        $seasonsTable->saveOrFail($nextSeason);
+
+        $teamSeasonsTable->saveOrFail($teamSeasonsTable->newEntity([
+            'team_id' => 1,
+            'season_id' => $previousSeason->id,
+            'semester' => 1,
+        ]));
+        $teamSeasonsTable->saveOrFail($teamSeasonsTable->newEntity([
+            'team_id' => 1,
+            'season_id' => $nextSeason->id,
+            'semester' => 1,
+        ]));
+
+        $this->get('/seasons/1');
+        $this->assertResponseOk();
+
+        $previousTeamSeason = $this->viewVariable('previousTeamSeason');
+        $this->assertNotNull($previousTeamSeason);
+        $this->assertSame(2022, (int)$previousTeamSeason->season->end);
+
+        $nextTeamSeason = $this->viewVariable('nextTeamSeason');
+        $this->assertNotNull($nextTeamSeason);
+        $this->assertSame(2026, (int)$nextTeamSeason->season->end);
+    }
+
+    /**
      * Tests authorization skipped.
      */
     public function testAuthorizationSkipped(): void


### PR DESCRIPTION
This pull request introduces navigation improvements for the public Game and Season views, allowing users to easily move to previous or next games and team seasons. It also removes the "preview" and "recap" rich text fields from the Team Season admin add/edit forms, cleaning up the UI and related tests. Additionally, an admin layout fix ensures proper frame targeting for Turbo navigation.

**Navigation improvements:**

* Added logic and UI to `GameViewService` and `templates/Games/view.php` to display "previous" and "next" game navigation buttons within the same team season. (`src/Service/GameViewService.php`, `templates/Games/view.php`, `tests/TestCase/Controller/GamesControllerTest.php`) [[1]](diffhunk://#diff-ada9cb8c144984a942117e09711a06318fd2d12b015c234c58e4404473586da9R55-R63) [[2]](diffhunk://#diff-ada9cb8c144984a942117e09711a06318fd2d12b015c234c58e4404473586da9R108-R138) [[3]](diffhunk://#diff-9e86e6efb387849e4f46b48b1fd7e302d6071c44f7fa986cb161be183decc5eaR103-R121) [[4]](diffhunk://#diff-31a58dc12c17b243f562d693fcb2b8ddedbf1238e01b59754314cc1e8895093bR117-R133)
* Added logic and UI to `SeasonViewService` and `templates/Seasons/view.php` to display "previous" and "next" team season navigation buttons. (`src/Service/SeasonViewService.php`, `templates/Seasons/view.php`, `tests/TestCase/Controller/SeasonsControllerTest.php`) [[1]](diffhunk://#diff-44c22d917852337d7d6150794e2ae4e702e12026605768d000260accf987b86aR63-R65) [[2]](diffhunk://#diff-44c22d917852337d7d6150794e2ae4e702e12026605768d000260accf987b86aR114-R155) [[3]](diffhunk://#diff-60c4be12afceb99d52ee63f08c7d8a6cf3b501e0911598ffe60a6b5861b3a6bbR182-R200) [[4]](diffhunk://#diff-ee3a417f5a65152d55dfeeea6fe9ad6e208ef79da3fb074cdf3e6b52480a9433R146-R181)

**Admin form cleanup:**

* Removed the "Season Preview" and "Season Recap" rich text fields from the Team Season add and edit forms, as well as related help text. (`templates/Admin/TeamSeasons/add.php`, `templates/Admin/TeamSeasons/edit.php`) [[1]](diffhunk://#diff-c988625585245f3984ec4669fba4835f07ce961545871dd0bf667d6ae359bbc0L223-L256) [[2]](diffhunk://#diff-c988625585245f3984ec4669fba4835f07ce961545871dd0bf667d6ae359bbc0L289-L296) [[3]](diffhunk://#diff-bfdd514df10f22a77717756628aba78be3a69adb6a3cae762019d630d1c6aa09L212-L243)
* Updated tests to ensure the removed fields are no longer present in the forms. (`tests/TestCase/Controller/Admin/TeamSeasonsControllerTest.php`) [[1]](diffhunk://#diff-1162d53fcd93c6768b17b741d399e5e41a4d4a8d8a878ee2a78c7a511265fee9L154-R155) [[2]](diffhunk://#diff-1162d53fcd93c6768b17b741d399e5e41a4d4a8d8a878ee2a78c7a511265fee9R430-R447)

**Turbo frame targeting fix:**

* Updated the admin layout to set the `target="_top"` attribute on the Turbo frame, ensuring redirects after authentication work correctly, and added a test for this behavior. (`templates/element/Layout/admin_shell.php`, `tests/TestCase/Controller/Admin/AppControllerTest.php`) [[1]](diffhunk://#diff-7d8e2b364b8c1e962ed937dc5a1ba697346b7398baa767adc8018159d0c073ccL83-R83) [[2]](diffhunk://#diff-67b349916b2d7c927575f0bc0f8e82a3592b8ccc91c49134d68ad899d98f16b2R58-R71)