### PR TITLE
Phase 2 ad lifecycle modernization with Stimulus-only ad delivery

### DIFF
--- a/e2e/ad-integration.spec.js
+++ b/e2e/ad-integration.spec.js
@@ -1,0 +1,139 @@
+import { expect, test } from "@playwright/test";
+
+function customAdMarkup() {
+    return `
+        <section class="rh-ad-slot" data-controller="ad-delivery" data-ad-delivery-mode-value="custom">
+            <div class="rh-ad-slot__inner" data-ad-delivery-target="container"></div>
+            <template data-ad-delivery-target="template"><div class="custom-ad">Custom Ad</div></template>
+        </section>
+    `;
+}
+
+function googleAdMarkup() {
+    return `
+        <section
+            class="rh-ad-slot rh-ad-slot--google"
+            data-controller="ad-delivery"
+            data-ad-delivery-mode-value="google"
+            data-ad-delivery-google-slot-id-value="1234567890"
+            data-ad-delivery-google-client-value="ca-pub-4154"
+            data-ad-delivery-google-format-value="auto"
+        >
+            <div class="rh-ad-slot__inner" data-ad-delivery-target="container"></div>
+        </section>
+    `;
+}
+
+test.describe("Ad lifecycle integration", () => {
+    test("re-renders custom ad content on turbo-frame replacement", async ({
+        page,
+    }) => {
+        await page.goto("/", { waitUntil: "domcontentloaded" });
+
+        await page.evaluate((markup) => {
+            const existing = document.getElementById("ad-test-frame");
+            if (existing) {
+                existing.remove();
+            }
+
+            const frame = document.createElement("turbo-frame");
+            frame.id = "ad-test-frame";
+            frame.innerHTML = markup;
+            document.body.appendChild(frame);
+        }, customAdMarkup());
+
+        await page.waitForSelector("#ad-test-frame .custom-ad", {
+            timeout: 10000,
+            state: "attached",
+        });
+
+        let customAdCount = await page.evaluate(() => {
+            return document.querySelectorAll("#ad-test-frame .custom-ad").length;
+        });
+        expect(customAdCount).toBe(1);
+
+        await page.evaluate((markup) => {
+            const frame = document.getElementById("ad-test-frame");
+            if (frame) {
+                frame.innerHTML = markup;
+            }
+        }, customAdMarkup());
+
+        await page.waitForSelector("#ad-test-frame .custom-ad", {
+            timeout: 10000,
+            state: "attached",
+        });
+
+        customAdCount = await page.evaluate(() => {
+            return document.querySelectorAll("#ad-test-frame .custom-ad").length;
+        });
+        expect(customAdCount).toBe(1);
+    });
+
+    test("re-initializes google ad slots on turbo-frame replacement without duplicate nodes", async ({
+        page,
+    }) => {
+        await page.goto("/", { waitUntil: "domcontentloaded" });
+
+        await page.evaluate(() => {
+            window.adsbygoogle = [];
+        });
+
+        await page.evaluate((markup) => {
+            const existing = document.getElementById("ad-test-frame");
+            if (existing) {
+                existing.remove();
+            }
+
+            const frame = document.createElement("turbo-frame");
+            frame.id = "ad-test-frame";
+            frame.innerHTML = markup;
+            document.body.appendChild(frame);
+        }, googleAdMarkup());
+
+        await page.waitForFunction(() => {
+            const section = document.querySelector("#ad-test-frame .rh-ad-slot");
+            const ad = section?.querySelector("ins.adsbygoogle");
+
+            return !!section && !!ad && section.getAttribute("data-rh-ad-initialized") === "1";
+        });
+
+        const firstPass = await page.evaluate(() => {
+            return {
+                queueLength: Array.isArray(window.adsbygoogle)
+                    ? window.adsbygoogle.length
+                    : 0,
+                insCount: document.querySelectorAll(
+                    "#ad-test-frame ins.adsbygoogle",
+                ).length,
+            };
+        });
+        expect(firstPass.queueLength).toBe(1);
+        expect(firstPass.insCount).toBe(1);
+
+        await page.evaluate((markup) => {
+            const frame = document.getElementById("ad-test-frame");
+            if (frame) {
+                frame.innerHTML = markup;
+            }
+        }, googleAdMarkup());
+
+        await page.waitForFunction(() => {
+            const section = document.querySelector("#ad-test-frame .rh-ad-slot");
+            return section?.getAttribute("data-rh-ad-initialized") === "1";
+        });
+
+        const secondPass = await page.evaluate(() => {
+            return {
+                queueLength: Array.isArray(window.adsbygoogle)
+                    ? window.adsbygoogle.length
+                    : 0,
+                insCount: document.querySelectorAll(
+                    "#ad-test-frame ins.adsbygoogle",
+                ).length,
+            };
+        });
+        expect(secondPass.queueLength).toBe(2);
+        expect(secondPass.insCount).toBe(1);
+    });
+});

--- a/js/controllers/ad_delivery_controller.js
+++ b/js/controllers/ad_delivery_controller.js
@@ -1,0 +1,123 @@
+import { Controller } from "@hotwired/stimulus";
+
+import {
+    destroyGoogleAdSlotSection,
+    initGoogleAdSlotSection,
+} from "../lib/google_ads.js";
+
+export default class extends Controller {
+    static targets = ["container", "template"];
+
+    static values = {
+        mode: String,
+        slot: String,
+        googleSlotId: String,
+        googleClient: String,
+        googleFormat: String,
+        googleLayout: String,
+        googleLayoutKey: String,
+        googleFullWidthResponsive: String,
+    };
+
+    connect() {
+        if (!this.hasContainerTarget) {
+            return;
+        }
+
+        this.clearContainer();
+
+        if (this.isGoogleMode()) {
+            this.renderGoogleAd();
+            return;
+        }
+
+        this.renderCustomAd();
+    }
+
+    disconnect() {
+        if (this.isGoogleMode()) {
+            destroyGoogleAdSlotSection(this.element);
+        }
+
+        this.clearContainer();
+    }
+
+    isGoogleMode() {
+        return this.modeValue === "google";
+    }
+
+    clearContainer() {
+        if (!this.hasContainerTarget) {
+            return;
+        }
+
+        this.containerTarget.innerHTML = "";
+    }
+
+    renderCustomAd() {
+        if (!this.hasTemplateTarget) {
+            return;
+        }
+
+        const fragment = this.templateTarget.content.cloneNode(true);
+        this.containerTarget.appendChild(fragment);
+        this.element.setAttribute("data-rh-ad-initialized", "1");
+    }
+
+    renderGoogleAd() {
+        const adElement = document.createElement("ins");
+        adElement.className = "adsbygoogle";
+        adElement.style.display = "block";
+        this.applyGoogleAttributes(adElement);
+
+        this.containerTarget.appendChild(adElement);
+        initGoogleAdSlotSection(this.element);
+    }
+
+    applyGoogleAttributes(adElement) {
+        this.assignDataAttribute(
+            adElement,
+            "data-ad-slot",
+            this.googleSlotIdValue,
+        );
+        this.assignDataAttribute(
+            adElement,
+            "data-ad-client",
+            this.googleClientValue,
+        );
+        this.assignDataAttribute(
+            adElement,
+            "data-ad-format",
+            this.googleFormatValue,
+        );
+        this.assignDataAttribute(
+            adElement,
+            "data-ad-layout",
+            this.googleLayoutValue,
+        );
+        this.assignDataAttribute(
+            adElement,
+            "data-ad-layout-key",
+            this.googleLayoutKeyValue,
+        );
+
+        const fullWidthResponsive = this.googleFullWidthResponsiveValue.trim();
+        if (fullWidthResponsive !== "") {
+            adElement.setAttribute(
+                "data-full-width-responsive",
+                fullWidthResponsive,
+            );
+        } else {
+            adElement.setAttribute("data-full-width-responsive", "true");
+        }
+    }
+
+    assignDataAttribute(element, attributeName, value) {
+        const normalizedValue = String(value || "").trim();
+        if (normalizedValue === "") {
+            return;
+        }
+
+        element.setAttribute(attributeName, normalizedValue);
+    }
+}

--- a/js/lib/google_ads.js
+++ b/js/lib/google_ads.js
@@ -100,6 +100,81 @@ export function syncGoogleAdSlotState(section, adElement) {
     return false;
 }
 
+function disconnectObserver(section) {
+    const observer = section?.__rhGoogleAdObserver;
+    if (!observer || typeof observer.disconnect !== "function") {
+        return;
+    }
+
+    observer.disconnect();
+    delete section.__rhGoogleAdObserver;
+}
+
+export function destroyGoogleAdSlotSection(section) {
+    if (!isElement(section)) {
+        return;
+    }
+
+    disconnectObserver(section);
+    section.classList.remove(EMPTY_SLOT_CLASS);
+    section.removeAttribute("data-rh-ad-initialized");
+    delete section.dataset.rhGoogleTagQueued;
+}
+
+export function initGoogleAdSlotSection(section) {
+    if (!isElement(section)) {
+        return false;
+    }
+
+    if (section.dataset.rhAdInitialized === "1") {
+        return false;
+    }
+
+    if (queueGoogleTagDisplay(section)) {
+        section.setAttribute("data-rh-ad-initialized", "1");
+        return true;
+    }
+
+    const adElement = section.querySelector(".adsbygoogle, ins.adsbygoogle");
+
+    if (!adElement) {
+        section.setAttribute("data-rh-ad-initialized", "1");
+        return true;
+    }
+
+    const queue = ensureGoogleQueue();
+    const wasRendered =
+        adElement.getAttribute("data-adsbygoogle-status") === "done";
+
+    if (queue && !wasRendered) {
+        queue.push({});
+    }
+
+    section.setAttribute("data-rh-ad-initialized", "1");
+
+    const canObserveStatus =
+        typeof globalThis !== "undefined" &&
+        typeof globalThis.MutationObserver === "function";
+
+    if (canObserveStatus) {
+        disconnectObserver(section);
+        const observer = new globalThis.MutationObserver(() => {
+            syncGoogleAdSlotState(section, adElement);
+        });
+
+        observer.observe(adElement, {
+            attributes: true,
+            attributeFilter: ["data-ad-status"],
+        });
+
+        section.__rhGoogleAdObserver = observer;
+    }
+
+    syncGoogleAdSlotState(section, adElement);
+
+    return true;
+}
+
 export function initGoogleAdSlots(root = document) {
     if (!root || typeof root.querySelectorAll !== "function") {
         return [];
@@ -109,52 +184,10 @@ export function initGoogleAdSlots(root = document) {
     const initialized = [];
 
     sections.forEach((section) => {
-        if (section.dataset.rhAdInitialized === "1") {
+        if (!initGoogleAdSlotSection(section)) {
             return;
         }
 
-        if (queueGoogleTagDisplay(section)) {
-            section.setAttribute("data-rh-ad-initialized", "1");
-            initialized.push(section);
-            return;
-        }
-
-        const adElement = section.querySelector(
-            ".adsbygoogle, ins.adsbygoogle",
-        );
-
-        if (!adElement) {
-            section.setAttribute("data-rh-ad-initialized", "1");
-            return;
-        }
-
-        const queue = ensureGoogleQueue();
-        const wasRendered =
-            adElement.getAttribute("data-adsbygoogle-status") === "done";
-
-        if (queue && !wasRendered) {
-            queue.push({});
-        }
-
-        section.setAttribute("data-rh-ad-initialized", "1");
-
-        const canObserveStatus =
-            typeof globalThis !== "undefined" &&
-            typeof globalThis.MutationObserver === "function";
-
-        if (canObserveStatus) {
-            const observer = new globalThis.MutationObserver(() => {
-                syncGoogleAdSlotState(section, adElement);
-            });
-
-            observer.observe(adElement, {
-                attributes: true,
-                attributeFilter: ["data-ad-status"],
-            });
-
-            section.__rhGoogleAdObserver = observer;
-        }
-        syncGoogleAdSlotState(section, adElement);
         initialized.push(section);
     });
 

--- a/js/main.js
+++ b/js/main.js
@@ -8,7 +8,6 @@ import {
 } from "./lib/admin_runtime.js";
 import { startNativeBridge } from "./lib/native_bridge.js";
 import { registerServiceWorker } from "./lib/pwa.js";
-import { initGoogleAdSlots } from "./lib/google_ads.js";
 import { initAdminRbacUi } from "./lib/admin_rbac_ui.js";
 import { initTurboScrollBehavior } from "./lib/turbo_scroll.js";
 import { initTinyMceLoader } from "./lib/tinymce_loader.js";
@@ -88,7 +87,6 @@ if (!runtimeAlreadyBooted) {
     startNativeBridge();
     // Service worker registration is async but non-blocking for the app
     void registerServiceWorker();
-    initGoogleAdSlots(document);
     initTurboScrollBehavior();
     initTinyMceLoader();
     const stimulus = Application.start();
@@ -171,13 +169,11 @@ if (hasWindow && !window.__RH_ADMIN_PATH_THEME_WATCHER_INIT__) {
 }
 
 document.addEventListener("turbo:load", () => {
-    initGoogleAdSlots(document);
     initAdminRbacUi(document);
 });
 
 document.addEventListener("turbo:frame-load", (event) => {
     const frame = event?.target;
-    initGoogleAdSlots(isElementNode(frame) ? frame : document);
     initAdminRbacUi(isElementNode(frame) ? frame : document);
 });
 

--- a/js/route_modules/public_core.js
+++ b/js/route_modules/public_core.js
@@ -1,10 +1,12 @@
 // Ensure Bootstrap's JS bundle is available for public pages (collapse, dropdowns, etc.)
 import "bootstrap/dist/js/bootstrap.bundle.min.js";
+import AdDeliveryController from "../controllers/ad_delivery_controller.js";
 import PublicShellController from "../controllers/public_shell_controller.js";
 import NavAccordionController from "../controllers/nav_accordion_controller.js";
 import ThemeToggleController from "../controllers/theme_toggle_controller.js";
 
 export function registerPublicCoreControllers(stimulus) {
+    stimulus.register("ad-delivery", AdDeliveryController);
     stimulus.register("public-shell", PublicShellController);
     stimulus.register("nav-accordion", NavAccordionController);
     stimulus.register("theme-toggle", ThemeToggleController);

--- a/js/tests/ad_delivery_controller.test.js
+++ b/js/tests/ad_delivery_controller.test.js
@@ -1,0 +1,155 @@
+/* global afterEach, beforeEach, describe, expect, test */
+
+import { Application } from "@hotwired/stimulus";
+
+import AdDeliveryController from "../controllers/ad_delivery_controller.js";
+
+describe("ad-delivery controller", () => {
+    let application;
+
+    const flush = async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+    };
+
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        delete window.adsbygoogle;
+        delete window.googletag;
+    });
+
+    afterEach(() => {
+        if (application) {
+            application.stop();
+            application = null;
+        }
+
+        document.body.innerHTML = "";
+        delete window.adsbygoogle;
+        delete window.googletag;
+    });
+
+    test("renders custom template content on connect", async () => {
+        document.body.innerHTML = `
+            <section data-controller="ad-delivery" data-ad-delivery-mode-value="custom">
+                <div data-ad-delivery-target="container"></div>
+                <template data-ad-delivery-target="template"><div class="custom-ad">Ad HTML</div></template>
+            </section>
+        `;
+
+        application = Application.start();
+        application.register("ad-delivery", AdDeliveryController);
+        await flush();
+
+        const section = document.querySelector("section");
+        const container = section.querySelector(
+            "[data-ad-delivery-target='container']",
+        );
+
+        expect(container.innerHTML).toContain("custom-ad");
+        expect(section.getAttribute("data-rh-ad-initialized")).toBe("1");
+    });
+
+    test("clears custom content on disconnect", async () => {
+        document.body.innerHTML = `
+            <section data-controller="ad-delivery" data-ad-delivery-mode-value="custom">
+                <div data-ad-delivery-target="container"></div>
+                <template data-ad-delivery-target="template"><div class="custom-ad">Ad HTML</div></template>
+            </section>
+        `;
+
+        application = Application.start();
+        application.register("ad-delivery", AdDeliveryController);
+        await flush();
+
+        const controller = application.controllers.find(
+            (item) => item.identifier === "ad-delivery",
+        );
+        const section = document.querySelector("section");
+        const container = section.querySelector(
+            "[data-ad-delivery-target='container']",
+        );
+
+        expect(container.innerHTML).toContain("custom-ad");
+
+        controller.disconnect();
+
+        expect(container.innerHTML).toBe("");
+    });
+
+    test("renders a google ins element and pushes ads queue once", async () => {
+        document.body.innerHTML = `
+            <section
+                class="rh-ad-slot rh-ad-slot--google"
+                data-controller="ad-delivery"
+                data-ad-delivery-mode-value="google"
+                data-ad-delivery-google-slot-id-value="1234567890"
+                data-ad-delivery-google-client-value="ca-pub-4154"
+                data-ad-delivery-google-format-value="auto"
+            >
+                <div data-ad-delivery-target="container"></div>
+            </section>
+        `;
+
+        application = Application.start();
+        application.register("ad-delivery", AdDeliveryController);
+        await flush();
+
+        const section = document.querySelector("section");
+        const ad = section.querySelector("ins.adsbygoogle");
+
+        expect(ad).not.toBeNull();
+        expect(ad.getAttribute("data-ad-slot")).toBe("1234567890");
+        expect(ad.getAttribute("data-ad-client")).toBe("ca-pub-4154");
+        expect(ad.getAttribute("data-ad-format")).toBe("auto");
+        expect(ad.getAttribute("data-full-width-responsive")).toBe("true");
+
+        expect(window.adsbygoogle).toBeDefined();
+        expect(window.adsbygoogle).toHaveLength(1);
+        expect(section.getAttribute("data-rh-ad-initialized")).toBe("1");
+    });
+
+    test("tears down google section state on disconnect", async () => {
+        document.body.innerHTML = `
+            <section
+                class="rh-ad-slot rh-ad-slot--google"
+                data-controller="ad-delivery"
+                data-ad-delivery-mode-value="google"
+                data-ad-delivery-google-slot-id-value="1234567890"
+            >
+                <div data-ad-delivery-target="container"></div>
+            </section>
+        `;
+
+        application = Application.start();
+        application.register("ad-delivery", AdDeliveryController);
+        await flush();
+
+        const controller = application.controllers.find(
+            (item) => item.identifier === "ad-delivery",
+        );
+        const section = document.querySelector("section");
+        const container = section.querySelector(
+            "[data-ad-delivery-target='container']",
+        );
+
+        controller.disconnect();
+
+        expect(container.innerHTML).toBe("");
+        expect(section.getAttribute("data-rh-ad-initialized")).toBeNull();
+        expect(section.classList.contains("rh-ad-slot--empty")).toBe(false);
+    });
+
+    test("handles missing container target without throwing", async () => {
+        document.body.innerHTML = `
+            <section data-controller="ad-delivery" data-ad-delivery-mode-value="custom"></section>
+        `;
+
+        expect(() => {
+            application = Application.start();
+            application.register("ad-delivery", AdDeliveryController);
+        }).not.toThrow();
+
+        await flush();
+    });
+});

--- a/js/tests/google_ads.test.js
+++ b/js/tests/google_ads.test.js
@@ -159,4 +159,28 @@ describe("google ad slot lifecycle", () => {
         const { syncGoogleAdSlotState } = await import("../lib/google_ads.js");
         expect(syncGoogleAdSlotState(null, null)).toBe(false);
     });
+
+    test("initializes and tears down a single google section", async () => {
+        document.body.innerHTML = `
+            <section class="rh-ad-slot rh-ad-slot--google" data-ad-slot="below_nav" data-google-mode="1">
+                <div class="rh-ad-slot__inner">
+                    <ins class="adsbygoogle" data-ad-status="filled"></ins>
+                </div>
+            </section>
+        `;
+
+        const { destroyGoogleAdSlotSection, initGoogleAdSlotSection } =
+            await import("../lib/google_ads.js");
+
+        const section = document.querySelector(".rh-ad-slot--google");
+        const initialized = initGoogleAdSlotSection(section);
+
+        expect(initialized).toBe(true);
+        expect(section.dataset.rhAdInitialized).toBe("1");
+
+        destroyGoogleAdSlotSection(section);
+
+        expect(section.getAttribute("data-rh-ad-initialized")).toBeNull();
+        expect(section.classList.contains("rh-ad-slot--empty")).toBe(false);
+    });
 });

--- a/js/tests/route_modules.test.js
+++ b/js/tests/route_modules.test.js
@@ -135,6 +135,7 @@ describe("Route Module Controller Registration", () => {
     describe("Public modules", () => {
         test("registerPublicCoreControllers registers public shell and navigation", () => {
             registerPublicCoreControllers(application);
+            expect(registeredControllers.has("ad-delivery")).toBe(true);
             expect(registeredControllers.has("public-shell")).toBe(true);
             expect(registeredControllers.has("nav-accordion")).toBe(true);
             expect(registeredControllers.has("theme-toggle")).toBe(true);

--- a/js/tests/route_modules_extended.test.js
+++ b/js/tests/route_modules_extended.test.js
@@ -21,6 +21,10 @@ describe("Route modules extended coverage", () => {
         test("public_core registers controllers", () => {
             registerPublicCoreControllers(mockStimulus);
             expect(mockStimulus.register).toHaveBeenCalledWith(
+                "ad-delivery",
+                expect.any(Function),
+            );
+            expect(mockStimulus.register).toHaveBeenCalledWith(
                 "public-shell",
                 expect.any(Function),
             );

--- a/src/Service/AdConfigurationService.php
+++ b/src/Service/AdConfigurationService.php
@@ -1,0 +1,194 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service;
+
+/**
+ * Service layer for ad slot configuration normalization.
+ *
+ * Reads ad slot configuration from runtime SiteOptions and exposes a typed
+ * payload used by the view helper and frontend lifecycle controller.
+ */
+class AdConfigurationService
+{
+    private SiteOptionsService $siteOptionsService;
+
+    /**
+     * @param \App\Service\SiteOptionsService|null $siteOptionsService
+     */
+    public function __construct(?SiteOptionsService $siteOptionsService = null)
+    {
+        $this->siteOptionsService = $siteOptionsService ?? new SiteOptionsService();
+    }
+
+    /**
+     * Build normalized slot configuration for a named ad placement.
+     *
+     * @param string $slot
+     * @return array{
+     *   slot:string,
+     *   active:bool,
+     *   mode:string,
+     *   html:string,
+     *   google_slot_id:string,
+     *   google_client:string,
+     *   google_format:string,
+     *   google_layout:string,
+     *   google_layout_key:string,
+     *   google_full_width_responsive:string
+     * }
+     */
+    public function getSlotConfiguration(string $slot): array
+    {
+        $normalizedSlot = trim($slot);
+        if ($normalizedSlot === '') {
+            return $this->emptySlotConfiguration('');
+        }
+
+        $settings = $this->siteOptionsService->getRuntimeSettings();
+        $active = $this->toBool($settings['ad_' . $normalizedSlot . '_active'] ?? false);
+        $html = trim((string)($settings['ad_' . $normalizedSlot . '_html'] ?? ''));
+        $googleModeEnabled = $this->toBool($settings['ad_' . $normalizedSlot . '_google_mode'] ?? false);
+
+        if (!$active || $html === '') {
+            return $this->emptySlotConfiguration($normalizedSlot);
+        }
+
+        $publisherId = trim((string)($settings['ad_publisher_id'] ?? ''));
+        $googleClient = $this->extractAttribute($html, 'data-ad-client');
+        if ($googleClient === '') {
+            $googleClient = $this->normalizePublisherId($publisherId);
+        }
+
+        $googleSlotId = $this->extractNumericAttribute($html, 'data-ad-slot');
+        $googleFormat = $this->extractAttribute($html, 'data-ad-format');
+        $googleLayout = $this->extractAttribute($html, 'data-ad-layout');
+        $googleLayoutKey = $this->extractAttribute($html, 'data-ad-layout-key');
+        $googleFullWidthResponsive = $this->extractAttribute($html, 'data-full-width-responsive');
+
+        $googleRenderable = $googleModeEnabled && $googleSlotId !== '';
+
+        return [
+            'slot' => $normalizedSlot,
+            'active' => true,
+            'mode' => $googleRenderable ? 'google' : 'custom',
+            'html' => $html,
+            'google_slot_id' => $googleSlotId,
+            'google_client' => $googleClient,
+            'google_format' => $googleFormat,
+            'google_layout' => $googleLayout,
+            'google_layout_key' => $googleLayoutKey,
+            'google_full_width_responsive' => $googleFullWidthResponsive,
+        ];
+    }
+
+    /**
+     * @param string $slot
+     * @return array{
+     *   slot:string,
+     *   active:bool,
+     *   mode:string,
+     *   html:string,
+     *   google_slot_id:string,
+     *   google_client:string,
+     *   google_format:string,
+     *   google_layout:string,
+     *   google_layout_key:string,
+     *   google_full_width_responsive:string
+     * }
+     */
+    private function emptySlotConfiguration(string $slot): array
+    {
+        return [
+            'slot' => $slot,
+            'active' => false,
+            'mode' => 'custom',
+            'html' => '',
+            'google_slot_id' => '',
+            'google_client' => '',
+            'google_format' => '',
+            'google_layout' => '',
+            'google_layout_key' => '',
+            'google_full_width_responsive' => '',
+        ];
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function toBool(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_numeric($value)) {
+            return (int)$value === 1;
+        }
+
+        if (is_string($value)) {
+            $normalized = strtolower(trim($value));
+
+            return in_array($normalized, ['1', 'true', 'yes', 'on'], true);
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $html
+     * @param string $attribute
+     */
+    private function extractAttribute(string $html, string $attribute): string
+    {
+        $pattern = '/\b' . preg_quote($attribute, '/') . '\s*=\s*(["\'])([^"\']+)\1/i';
+        if (preg_match($pattern, $html, $matches) !== 1) {
+            return '';
+        }
+
+        return trim((string)($matches[2] ?? ''));
+    }
+
+    /**
+     * @param string $html
+     * @param string $attribute
+     */
+    private function extractNumericAttribute(string $html, string $attribute): string
+    {
+        $value = $this->extractAttribute($html, $attribute);
+        if ($value !== '' && ctype_digit($value)) {
+            return $value;
+        }
+
+        return '';
+    }
+
+    /**
+     * @param string $publisherId
+     */
+    private function normalizePublisherId(string $publisherId): string
+    {
+        $candidate = trim($publisherId);
+        if ($candidate === '') {
+            return '';
+        }
+
+        if (ctype_digit($candidate)) {
+            return 'ca-pub-' . $candidate;
+        }
+
+        if (preg_match('/^ca-pub-\d+$/i', $candidate) === 1) {
+            return strtolower($candidate);
+        }
+
+        if (preg_match('/^pub-\d+$/i', $candidate) === 1) {
+            return 'ca-' . strtolower($candidate);
+        }
+
+        if (preg_match('/ca-pub-\d+/i', $candidate, $matches) === 1) {
+            return strtolower((string)$matches[0]);
+        }
+
+        return $candidate;
+    }
+}

--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -24,6 +24,7 @@ use Cake\View\View;
  * Your application's default view class
  *
  * @link https://book.cakephp.org/5/en/views.html#the-app-view
+ * @property \App\View\Helper\AdHelper $Ad
  * @property \App\View\Helper\ImageServeHelper $ImageServe
  * @property \CakeVite\View\Helper\ViteHelper $Vite
  * @property \Cake\View\Helper\FormHelper $Form
@@ -46,6 +47,7 @@ class AppView extends View
     {
         parent::initialize();
 
+        $this->loadHelper('Ad');
         $this->loadHelper('ImageServe');
         $this->loadHelper('SocialLinks');
         $this->loadHelper('Rbac');

--- a/src/View/Helper/AdHelper.php
+++ b/src/View/Helper/AdHelper.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+namespace App\View\Helper;
+
+use App\Service\AdConfigurationService;
+use Cake\View\Helper;
+use Cake\View\View;
+
+/**
+ * View helper for ad slot rendering payloads.
+ */
+class AdHelper extends Helper
+{
+    private AdConfigurationService $adConfigurationService;
+
+    /**
+     * @param \Cake\View\View $View
+     * @param array<string,mixed> $config
+     */
+    public function __construct(View $View, array $config = [])
+    {
+        parent::__construct($View, $config);
+
+        $service = $config['adConfigurationService'] ?? null;
+        if ($service instanceof AdConfigurationService) {
+            $this->adConfigurationService = $service;
+
+            return;
+        }
+
+        $this->adConfigurationService = new AdConfigurationService();
+    }
+
+    /**
+     * Resolve normalized payload for a slot name.
+     *
+     * @param string $slot
+     * @return array{
+     *   slot:string,
+     *   slot_class:string,
+     *   active:bool,
+     *   mode:string,
+     *   is_google:bool,
+     *   html:string,
+     *   google_slot_id:string,
+     *   google_client:string,
+     *   google_format:string,
+     *   google_layout:string,
+     *   google_layout_key:string,
+     *   google_full_width_responsive:string
+     * }
+     */
+    public function slot(string $slot): array
+    {
+        $configuration = $this->adConfigurationService->getSlotConfiguration($slot);
+        $slotName = (string)($configuration['slot'] ?? '');
+        $mode = (string)($configuration['mode'] ?? 'custom');
+
+        return [
+            'slot' => $slotName,
+            'slot_class' => str_replace('_', '-', $slotName),
+            'active' => (bool)($configuration['active'] ?? false),
+            'mode' => $mode,
+            'is_google' => $mode === 'google',
+            'html' => (string)($configuration['html'] ?? ''),
+            'google_slot_id' => (string)($configuration['google_slot_id'] ?? ''),
+            'google_client' => (string)($configuration['google_client'] ?? ''),
+            'google_format' => (string)($configuration['google_format'] ?? ''),
+            'google_layout' => (string)($configuration['google_layout'] ?? ''),
+            'google_layout_key' => (string)($configuration['google_layout_key'] ?? ''),
+            'google_full_width_responsive' => (string)($configuration['google_full_width_responsive'] ?? ''),
+        ];
+    }
+}

--- a/templates/element/Ads/block.php
+++ b/templates/element/Ads/block.php
@@ -1,37 +1,64 @@
 <?php
 declare(strict_types=1);
 
-use Cake\Core\Configure;
-
 /**
- * Generic ad slot renderer backed by SiteOptions.
- *
- * Expected option keys per slot:
- * - ad_{slot}_active (checkbox)
- * - ad_{slot}_html (text/textarea)
- * - ad_{slot}_google_mode (checkbox)
+ * Generic ad slot renderer backed by SiteOptions through AdHelper payloads.
  *
  * @var \App\View\AppView $this
  * @var string $slot
  */
 
-$slot = isset($slot) ? trim((string)$slot) : '';
-if ($slot === '') {
+$slotName = isset($slot) ? trim((string)$slot) : '';
+if ($slotName === '') {
     return;
 }
 
-$active = (bool)Configure::read('SiteOptions.ad_' . $slot . '_active', false);
-$htmlBlock = trim((string)Configure::read('SiteOptions.ad_' . $slot . '_html', ''));
-$googleMode = (bool)Configure::read('SiteOptions.ad_' . $slot . '_google_mode', false);
-
-if (!$active || $htmlBlock === '') {
+$slotConfig = $this->Ad->slot($slotName);
+if (!$slotConfig['active']) {
     return;
 }
 
-$slotClass = str_replace('_', '-', $slot);
+$isGoogle = $slotConfig['is_google'];
+$classes = 'rh-ad-slot rh-ad-slot--' . $slotConfig['slot_class'];
+if ($isGoogle) {
+    $classes .= ' rh-ad-slot--google';
+}
+
+$attributes = [
+    'class' => $classes,
+    'data-controller' => 'ad-delivery',
+    'data-ad-slot' => $slotConfig['slot'],
+    'data-google-mode' => $isGoogle ? '1' : '0',
+    'data-ad-delivery-mode-value' => $slotConfig['mode'],
+    'data-ad-delivery-slot-value' => $slotConfig['slot'],
+];
+
+if ($slotConfig['google_slot_id'] !== '') {
+    $attributes['data-ad-delivery-google-slot-id-value'] = $slotConfig['google_slot_id'];
+}
+if ($slotConfig['google_client'] !== '') {
+    $attributes['data-ad-delivery-google-client-value'] = $slotConfig['google_client'];
+}
+if ($slotConfig['google_format'] !== '') {
+    $attributes['data-ad-delivery-google-format-value'] = $slotConfig['google_format'];
+}
+if ($slotConfig['google_layout'] !== '') {
+    $attributes['data-ad-delivery-google-layout-value'] = $slotConfig['google_layout'];
+}
+if ($slotConfig['google_layout_key'] !== '') {
+    $attributes['data-ad-delivery-google-layout-key-value'] = $slotConfig['google_layout_key'];
+}
+if ($slotConfig['google_full_width_responsive'] !== '') {
+    $attributes['data-ad-delivery-google-full-width-responsive-value'] = $slotConfig['google_full_width_responsive'];
+}
 ?>
-<section class="rh-ad-slot rh-ad-slot--<?= h($slotClass) ?><?= $googleMode ? ' rh-ad-slot--google' : '' ?>" data-ad-slot="<?= h($slot) ?>" data-google-mode="<?= $googleMode ? '1' : '0' ?>">
-    <div class="rh-ad-slot__inner text-center">
-        <?= $htmlBlock ?>
-    </div>
+<section
+<?php foreach ($attributes as $attributeName => $attributeValue) : ?>
+    <?= h($attributeName) ?>="<?= h((string)$attributeValue) ?>"
+<?php endforeach; ?>
+>
+    <div class="rh-ad-slot__inner text-center" data-ad-delivery-target="container"></div>
+    <?php if (!$isGoogle) : ?>
+        <template data-ad-delivery-target="template"><?= $slotConfig['html'] ?></template>
+    <?php endif; ?>
 </section>

--- a/tests/TestCase/Service/AdConfigurationServiceTest.php
+++ b/tests/TestCase/Service/AdConfigurationServiceTest.php
@@ -1,0 +1,124 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\AdConfigurationService;
+use App\Service\SiteOptionsService;
+use Cake\TestSuite\TestCase;
+
+class AdConfigurationServiceTest extends TestCase
+{
+    /**
+     * Empty slot names should return an inactive payload.
+     */
+    public function testGetSlotConfigurationReturnsInactiveForEmptySlot(): void
+    {
+        $siteOptionsService = $this->createSiteOptionsServiceMock([]);
+        $service = new AdConfigurationService($siteOptionsService);
+
+        $result = $service->getSlotConfiguration('');
+
+        $this->assertFalse($result['active']);
+        $this->assertSame('', $result['slot']);
+        $this->assertSame('custom', $result['mode']);
+    }
+
+    /**
+     * Active custom mode slots should retain raw html and custom mode.
+     */
+    public function testGetSlotConfigurationReturnsCustomModePayload(): void
+    {
+        $siteOptionsService = $this->createSiteOptionsServiceMock([
+            'ad_below_nav_active' => true,
+            'ad_below_nav_html' => '<div class="ad-content">Custom Ad</div>',
+            'ad_below_nav_google_mode' => false,
+        ]);
+        $service = new AdConfigurationService($siteOptionsService);
+
+        $result = $service->getSlotConfiguration('below_nav');
+
+        $this->assertTrue($result['active']);
+        $this->assertSame('below_nav', $result['slot']);
+        $this->assertSame('custom', $result['mode']);
+        $this->assertStringContainsString('Custom Ad', $result['html']);
+        $this->assertSame('', $result['google_slot_id']);
+    }
+
+    /**
+     * Google mode slots should parse google metadata from slot html.
+     */
+    public function testGetSlotConfigurationParsesGoogleAttributes(): void
+    {
+        $siteOptionsService = $this->createSiteOptionsServiceMock([
+            'ad_below_nav_active' => true,
+            'ad_below_nav_google_mode' => true,
+            'ad_below_nav_html' =>
+                '<ins class="adsbygoogle" data-ad-client="ca-pub-123" data-ad-slot="9876543210" data-ad-format="auto" data-full-width-responsive="true"></ins>',
+        ]);
+        $service = new AdConfigurationService($siteOptionsService);
+
+        $result = $service->getSlotConfiguration('below_nav');
+
+        $this->assertTrue($result['active']);
+        $this->assertSame('google', $result['mode']);
+        $this->assertSame('9876543210', $result['google_slot_id']);
+        $this->assertSame('ca-pub-123', $result['google_client']);
+        $this->assertSame('auto', $result['google_format']);
+        $this->assertSame('true', $result['google_full_width_responsive']);
+    }
+
+    /**
+     * Numeric publisher ids should be normalized to ca-pub-* when client is absent.
+     */
+    public function testGetSlotConfigurationNormalizesPublisherIdFallback(): void
+    {
+        $siteOptionsService = $this->createSiteOptionsServiceMock([
+            'ad_below_nav_active' => true,
+            'ad_below_nav_google_mode' => true,
+            'ad_publisher_id' => '4154',
+            'ad_below_nav_html' =>
+                '<ins class="adsbygoogle" data-ad-slot="1234567890"></ins>',
+        ]);
+        $service = new AdConfigurationService($siteOptionsService);
+
+        $result = $service->getSlotConfiguration('below_nav');
+
+        $this->assertSame('google', $result['mode']);
+        $this->assertSame('ca-pub-4154', $result['google_client']);
+    }
+
+    /**
+     * Google mode should safely fall back to custom when no numeric slot id exists.
+     */
+    public function testGetSlotConfigurationFallsBackWhenSlotIdMissing(): void
+    {
+        $siteOptionsService = $this->createSiteOptionsServiceMock([
+            'ad_below_nav_active' => true,
+            'ad_below_nav_google_mode' => true,
+            'ad_below_nav_html' =>
+                '<ins class="adsbygoogle" data-ad-client="ca-pub-123"></ins>',
+        ]);
+        $service = new AdConfigurationService($siteOptionsService);
+
+        $result = $service->getSlotConfiguration('below_nav');
+
+        $this->assertSame('custom', $result['mode']);
+        $this->assertSame('', $result['google_slot_id']);
+        $this->assertStringContainsString('adsbygoogle', $result['html']);
+    }
+
+    /**
+     * @param array<string,mixed> $settings
+     */
+    private function createSiteOptionsServiceMock(array $settings): SiteOptionsService
+    {
+        $siteOptionsService = $this->getMockBuilder(SiteOptionsService::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getRuntimeSettings'])
+            ->getMock();
+        $siteOptionsService->method('getRuntimeSettings')->willReturn($settings);
+
+        return $siteOptionsService;
+    }
+}

--- a/tests/TestCase/View/Element/AdsBlockElementTest.php
+++ b/tests/TestCase/View/Element/AdsBlockElementTest.php
@@ -67,8 +67,10 @@ class AdsBlockElementTest extends TestCase
         $output = $this->view->element('Ads/block', ['slot' => 'below_nav']);
 
         $this->assertStringContainsString('rh-ad-slot--below-nav', $output);
+        $this->assertStringContainsString('data-controller="ad-delivery"', $output);
         $this->assertStringContainsString('data-google-mode="0"', $output);
-        $this->assertStringContainsString('<div class="ad-content">Ad</div>', $output);
+        $this->assertStringContainsString('data-ad-delivery-mode-value="custom"', $output);
+        $this->assertStringContainsString('<template data-ad-delivery-target="template"><div class="ad-content">Ad</div></template>', $output);
     }
 
     /**
@@ -77,13 +79,20 @@ class AdsBlockElementTest extends TestCase
     public function testGoogleModeRendersClassWithoutInlinePushScript(): void
     {
         Configure::write('SiteOptions.ad_below_nav_active', true);
-        Configure::write('SiteOptions.ad_below_nav_html', '<ins class="adsbygoogle"></ins>');
+        Configure::write(
+            'SiteOptions.ad_below_nav_html',
+            '<ins class="adsbygoogle" data-ad-client="ca-pub-111" data-ad-slot="1234567890"></ins>',
+        );
         Configure::write('SiteOptions.ad_below_nav_google_mode', true);
 
         $output = $this->view->element('Ads/block', ['slot' => 'below_nav']);
 
         $this->assertStringContainsString('rh-ad-slot--google', $output);
         $this->assertStringContainsString('data-google-mode="1"', $output);
+        $this->assertStringContainsString('data-ad-delivery-mode-value="google"', $output);
+        $this->assertStringContainsString('data-ad-delivery-google-slot-id-value="1234567890"', $output);
+        $this->assertStringContainsString('data-ad-delivery-google-client-value="ca-pub-111"', $output);
+        $this->assertStringNotContainsString('data-ad-delivery-target="template"', $output);
         $this->assertStringNotContainsString('(window.adsbygoogle = window.adsbygoogle || []).push({});', $output);
     }
 }

--- a/tests/TestCase/View/Helper/AdHelperTest.php
+++ b/tests/TestCase/View/Helper/AdHelperTest.php
@@ -1,0 +1,98 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\View\Helper;
+
+use App\View\Helper\AdHelper;
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+
+class AdHelperTest extends TestCase
+{
+    private AdHelper $helper;
+
+    /**
+     * @var mixed
+     */
+    private $originalSiteOptions;
+
+    /**
+     * Initialize helper and preserve prior runtime site options.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->helper = new AdHelper(new View());
+        $this->originalSiteOptions = Configure::read('SiteOptions');
+    }
+
+    /**
+     * Restore runtime options after each test.
+     */
+    public function tearDown(): void
+    {
+        Configure::delete('SiteOptions');
+        if ($this->originalSiteOptions !== null) {
+            Configure::write('SiteOptions', $this->originalSiteOptions);
+        }
+
+        unset($this->helper);
+        parent::tearDown();
+    }
+
+    /**
+     * Missing slots should return inactive payload defaults.
+     */
+    public function testSlotReturnsInactiveDefaultsWhenNotConfigured(): void
+    {
+        Configure::write('SiteOptions', []);
+
+        $payload = $this->helper->slot('below_nav');
+
+        $this->assertFalse($payload['active']);
+        $this->assertSame('below-nav', $payload['slot_class']);
+        $this->assertSame('custom', $payload['mode']);
+        $this->assertFalse($payload['is_google']);
+    }
+
+    /**
+     * Custom mode slots should retain html and derive slot class names.
+     */
+    public function testSlotReturnsCustomPayload(): void
+    {
+        Configure::write('SiteOptions.ad_below_nav_active', true);
+        Configure::write('SiteOptions.ad_below_nav_google_mode', false);
+        Configure::write('SiteOptions.ad_below_nav_html', '<div class="banner">Banner</div>');
+
+        $payload = $this->helper->slot('below_nav');
+
+        $this->assertTrue($payload['active']);
+        $this->assertSame('below-nav', $payload['slot_class']);
+        $this->assertSame('custom', $payload['mode']);
+        $this->assertFalse($payload['is_google']);
+        $this->assertStringContainsString('banner', $payload['html']);
+    }
+
+    /**
+     * Google mode slots should expose parsed ad attributes.
+     */
+    public function testSlotReturnsGooglePayload(): void
+    {
+        Configure::write('SiteOptions.ad_below_nav_active', true);
+        Configure::write('SiteOptions.ad_below_nav_google_mode', true);
+        Configure::write(
+            'SiteOptions.ad_below_nav_html',
+            '<ins class="adsbygoogle" data-ad-client="ca-pub-321" data-ad-slot="1234567890" data-ad-format="auto"></ins>',
+        );
+
+        $payload = $this->helper->slot('below_nav');
+
+        $this->assertTrue($payload['active']);
+        $this->assertSame('google', $payload['mode']);
+        $this->assertTrue($payload['is_google']);
+        $this->assertSame('1234567890', $payload['google_slot_id']);
+        $this->assertSame('ca-pub-321', $payload['google_client']);
+        $this->assertSame('auto', $payload['google_format']);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a new backend ad configuration layer via `AdConfigurationService` and `AdHelper`
- migrate ad slot rendering to helper-driven payloads in `templates/element/Ads/block.php`
- add a dedicated Stimulus `ad-delivery` controller and register it in public core controllers
- migrate ad lifecycle ownership to Stimulus connect/disconnect and remove global ad init hooks from `js/main.js`
- extend JS/PHP unit coverage and add targeted E2E ad lifecycle integration coverage

## Key backend changes
- added `src/Service/AdConfigurationService.php`
  - reads from runtime `SiteOptions` state (no per-slot DB query loops)
  - parses Google ad metadata from slot HTML including numeric `data-ad-slot`
  - normalizes publisher fallback (`ad_publisher_id`) to `ca-pub-*` when numeric
- added `src/View/Helper/AdHelper.php`
  - emits normalized slot payloads used by the ad element
- updated `src/View/AppView.php` to load `Ad` helper
- refactored `templates/element/Ads/block.php`
  - emits `data-controller="ad-delivery"` and Stimulus value attributes
  - uses `<template>` storage for custom HTML blocks and container target for runtime injection

## Key frontend changes
- added `js/controllers/ad_delivery_controller.js`
  - custom mode: template clone/inject on connect, purge on disconnect
  - google mode: programmatic `<ins class="adsbygoogle">` creation + queue push
  - teardown on disconnect to clear container and ad section state
- updated `js/lib/google_ads.js`
  - added section-level `initGoogleAdSlotSection` and `destroyGoogleAdSlotSection`
  - retained bulk initializer compatibility
- updated `js/route_modules/public_core.js`
  - registers `ad-delivery` controller
- updated `js/main.js`
  - removed global `initGoogleAdSlots` lifecycle calls to enforce single lifecycle path

## Tests added/updated
- added `tests/TestCase/Service/AdConfigurationServiceTest.php`
- added `tests/TestCase/View/Helper/AdHelperTest.php`
- updated `tests/TestCase/View/Element/AdsBlockElementTest.php`
- added `js/tests/ad_delivery_controller.test.js`
- updated `js/tests/google_ads.test.js`
- updated route module registration tests:
  - `js/tests/route_modules.test.js`
  - `js/tests/route_modules_extended.test.js`
- added targeted Playwright spec:
  - `e2e/ad-integration.spec.js`

## Validation run
- `npm run test:js`
- `composer test`
- `composer cs-check`
- `composer phpstan:check`
- `npm run lint:css`
- `npm run lint:js`
- `npm run format:js:check`
- `./scripts/e2e-local.sh -- --project=chromium e2e/ad-integration.spec.js --workers=1 --trace on`
- `./scripts/e2e-local.sh -- --project=chromium e2e/turbo-integration.spec.js --workers=1 --trace on`
- `./scripts/e2e-local.sh -- --project=chromium e2e/blog-pages.spec.js --workers=1 --trace on`

## Notes
- unrelated local modification remains unstaged in workspace: `config/Migrations/schema-dump-default.lock`
- composer/phpunit run outputs existing PHP startup deprecation notices for session ini settings, but test suites pass