### PR TITLE
Implement blog content service with image credits

### DIFF
--- a/js/controllers/blog_post_form_controller.js
+++ b/js/controllers/blog_post_form_controller.js
@@ -467,7 +467,7 @@ export default class extends Controller {
         }
 
         editor.insertContent(
-            `<picture><img src="${imageUrl}" alt="" class="img-fluid" loading="lazy"></picture><p></p>`,
+            `<picture><img src="${imageUrl}" data-image-id="${imageId}" alt="" class="img-fluid" loading="lazy"></picture><p></p>`,
         );
         this.inlineFieldTarget.value = "";
         delete this.inlineFieldTarget.dataset.selectedImageUrl;

--- a/js/tests/blog_post_form_controller.test.js
+++ b/js/tests/blog_post_form_controller.test.js
@@ -125,7 +125,7 @@ describe("blog-post-form controller", () => {
         inlineField.dispatchEvent(new Event("change", { bubbles: true }));
 
         expect(insertContent).toHaveBeenCalledWith(
-            '<picture><img src="/img/storage/99.jpg" alt="" class="img-fluid" loading="lazy"></picture><p></p>',
+            '<picture><img src="/img/storage/99.jpg" data-image-id="99" alt="" class="img-fluid" loading="lazy"></picture><p></p>',
         );
         expect(inlineField.value).toBe("");
         expect(inlineField.dataset.selectedImageUrl).toBeUndefined();

--- a/src/Service/BlogContentService.php
+++ b/src/Service/BlogContentService.php
@@ -1,0 +1,245 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Model\Entity\Image;
+use App\Model\Table\ImagesTable;
+use Cake\ORM\TableRegistry;
+use DOMDocument;
+use DOMElement;
+
+/**
+ * Adds metadata-driven photo credits to stored images in blog content.
+ */
+class BlogContentService
+{
+    private ImagesTable $imagesTable;
+
+    /**
+     * @param \App\Model\Table\ImagesTable|null $imagesTable
+     */
+    public function __construct(?ImagesTable $imagesTable = null)
+    {
+        /** @var \App\Model\Table\ImagesTable $table */
+        $table = $imagesTable ?? TableRegistry::getTableLocator()->get('Images');
+        $this->imagesTable = $table;
+    }
+
+    /**
+     * Add captions for credited stored images in a blog body.
+     *
+     * @param string $html Blog body HTML.
+     */
+    public function renderWithPhotoCredits(string $html): string
+    {
+        if (!str_contains(strtolower($html), '<img')) {
+            return $html;
+        }
+
+        $document = new DOMDocument('1.0', 'UTF-8');
+        $previousErrors = libxml_use_internal_errors(true);
+        $loaded = $document->loadHTML(
+            '<?xml encoding="UTF-8"><div id="rh-blog-content-root">' . $html . '</div>',
+            LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD,
+        );
+        libxml_clear_errors();
+        libxml_use_internal_errors($previousErrors);
+
+        if (!$loaded) {
+            return $html;
+        }
+
+        $root = $document->getElementById('rh-blog-content-root');
+        if (!$root instanceof DOMElement) {
+            return $html;
+        }
+
+        $imageElements = [];
+        $imageIds = [];
+        $imagePaths = [];
+        foreach ($root->getElementsByTagName('img') as $imageElement) {
+            if (!$imageElement instanceof DOMElement) {
+                continue;
+            }
+
+            $imageElements[] = $imageElement;
+            $imageId = $this->readImageId($imageElement);
+            if ($imageId > 0) {
+                $imageIds[$imageId] = $imageId;
+            }
+
+            $imagePath = $this->readStoredImagePath($imageElement->getAttribute('src'));
+            if ($imagePath !== '') {
+                $imagePaths[$imagePath] = $imagePath;
+            }
+        }
+
+        $images = $this->findImages(array_values($imageIds), array_values($imagePaths));
+        $renderedCredit = false;
+        foreach ($imageElements as $imageElement) {
+            $image = $this->resolveImage($imageElement, $images);
+            if (!$image || trim((string)$image->photo_credit) === '') {
+                continue;
+            }
+
+            $target = $imageElement->parentNode instanceof DOMElement
+                && strtolower($imageElement->parentNode->tagName) === 'picture'
+                ? $imageElement->parentNode
+                : $imageElement;
+
+            if (!$target->parentNode || $this->hasCreditWrapper($target)) {
+                continue;
+            }
+
+            $wrapper = $document->createElement('div');
+            $wrapper->setAttribute('class', 'blog-image-credit');
+            $existingClass = trim($target->getAttribute('class'));
+            if ($existingClass !== '') {
+                $wrapper->setAttribute('class', 'blog-image-credit ' . $existingClass);
+            }
+            $existingStyle = trim($target->getAttribute('style'));
+            if ($existingStyle !== '') {
+                $wrapper->setAttribute('style', $existingStyle);
+            }
+
+            $target->parentNode->replaceChild($wrapper, $target);
+            $wrapper->appendChild($target);
+
+            $caption = $document->createElement('figcaption');
+            $caption->setAttribute('class', 'blog-image-credit__label');
+            $caption->appendChild($document->createTextNode('Photo: ' . trim((string)$image->photo_credit)));
+            $wrapper->appendChild($caption);
+            $renderedCredit = true;
+        }
+
+        if (!$renderedCredit) {
+            return $html;
+        }
+
+        $output = '';
+        foreach ($root->childNodes as $child) {
+            $output .= $document->saveHTML($child);
+        }
+
+        return $output;
+    }
+
+    /**
+     * @param \DOMElement $imageElement
+     * @param array<string,\App\Model\Entity\Image> $images
+     */
+    private function resolveImage(DOMElement $imageElement, array $images): ?Image
+    {
+        $imageId = $this->readImageId($imageElement);
+        if ($imageId > 0 && isset($images['id:' . $imageId])) {
+            return $images['id:' . $imageId];
+        }
+
+        $path = $this->readStoredImagePath($imageElement->getAttribute('src'));
+        if ($path !== '' && isset($images['path:' . $path])) {
+            return $images['path:' . $path];
+        }
+
+        $filename = basename($path);
+
+        return $filename !== '' ? ($images['filename:' . $filename] ?? null) : null;
+    }
+
+    /**
+     * @param array<int,int> $imageIds
+     * @param array<int,string> $imagePaths
+     * @return array<string,\App\Model\Entity\Image>
+     */
+    private function findImages(array $imageIds, array $imagePaths): array
+    {
+        $filenames = [];
+        foreach ($imagePaths as $path) {
+            $filename = basename($path);
+            if ($filename !== '') {
+                $filenames[$filename] = $filename;
+            }
+        }
+
+        $conditions = [];
+        if ($imageIds !== []) {
+            $conditions[] = ['Images.id IN' => $imageIds];
+        }
+        if ($imagePaths !== []) {
+            $conditions[] = ['Images.storage_path IN' => $imagePaths];
+        }
+        if ($filenames !== []) {
+            $conditions[] = ['Images.filename IN' => array_values($filenames)];
+        }
+        if ($conditions === []) {
+            return [];
+        }
+
+        $found = $this->imagesTable->find()
+            ->where(['OR' => $conditions])
+            ->all();
+        $images = [];
+        foreach ($found as $image) {
+            if (!$image instanceof Image) {
+                continue;
+            }
+
+            $images['id:' . (int)$image->id] = $image;
+            $path = trim((string)$image->storage_path, '/');
+            if ($path !== '') {
+                $images['path:' . $path] = $image;
+            }
+            $filename = basename((string)$image->filename);
+            if ($filename !== '') {
+                $images['filename:' . $filename] = $image;
+            }
+        }
+
+        return $images;
+    }
+
+    /**
+     * Read a persisted image id from inline image markup.
+     *
+     * @param \DOMElement $imageElement
+     */
+    private function readImageId(DOMElement $imageElement): int
+    {
+        $value = trim($imageElement->getAttribute('data-image-id'));
+
+        return ctype_digit($value) ? (int)$value : 0;
+    }
+
+    /**
+     * Extract a local stored-image path from an image URL.
+     *
+     * @param string $src Image URL.
+     */
+    private function readStoredImagePath(string $src): string
+    {
+        $path = parse_url($src, PHP_URL_PATH);
+        if (!is_string($path) || !str_starts_with($path, '/img/storage/')) {
+            return '';
+        }
+
+        return trim(rawurldecode(substr($path, strlen('/img/storage/'))), '/');
+    }
+
+    /**
+     * Determine whether an image is already inside a credit wrapper.
+     *
+     * @param \DOMElement $element
+     */
+    private function hasCreditWrapper(DOMElement $element): bool
+    {
+        $parent = $element->parentNode;
+        while ($parent instanceof DOMElement) {
+            if (str_contains(' ' . $parent->getAttribute('class') . ' ', ' blog-image-credit ')) {
+                return true;
+            }
+            $parent = $parent->parentNode;
+        }
+
+        return false;
+    }
+}

--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -25,6 +25,7 @@ use Cake\View\View;
  *
  * @link https://book.cakephp.org/5/en/views.html#the-app-view
  * @property \App\View\Helper\AdHelper $Ad
+ * @property \App\View\Helper\BlogContentHelper $BlogContent
  * @property \App\View\Helper\ImageServeHelper $ImageServe
  * @property \CakeVite\View\Helper\ViteHelper $Vite
  * @property \Cake\View\Helper\FormHelper $Form
@@ -48,6 +49,7 @@ class AppView extends View
         parent::initialize();
 
         $this->loadHelper('Ad');
+        $this->loadHelper('BlogContent');
         $this->loadHelper('ImageServe');
         $this->loadHelper('SocialLinks');
         $this->loadHelper('Rbac');

--- a/src/View/Helper/BlogContentHelper.php
+++ b/src/View/Helper/BlogContentHelper.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace App\View\Helper;
+
+use App\Service\BlogContentService;
+use Cake\View\Helper;
+use Cake\View\View;
+
+/**
+ * View helper for rendering blog body content with image credits.
+ */
+class BlogContentHelper extends Helper
+{
+    private BlogContentService $blogContentService;
+
+    /**
+     * @param \Cake\View\View $View
+     * @param array<string,mixed> $config
+     */
+    public function __construct(View $View, array $config = [])
+    {
+        parent::__construct($View, $config);
+        $service = $config['blogContentService'] ?? null;
+        $this->blogContentService = $service instanceof BlogContentService
+            ? $service
+            : new BlogContentService();
+    }
+
+    /**
+     * Render blog HTML with photo credits for stored images.
+     *
+     * @param string $html Blog body HTML.
+     */
+    public function render(string $html): string
+    {
+        return $this->blogContentService->renderWithPhotoCredits($html);
+    }
+}

--- a/templates/element/blog/view_frame.php
+++ b/templates/element/blog/view_frame.php
@@ -44,7 +44,7 @@ declare(strict_types=1);
                 <?php endif; ?>
 
                 <div class="blog-content fs-5 lh-lg mb-5">
-                    <?= $post->body ?>
+                    <?= $this->BlogContent->render((string)$post->body) ?>
                 </div>
 
                 <?php if (!empty($post->blog_tags)) : ?>

--- a/tests/TestCase/Service/BlogContentServiceTest.php
+++ b/tests/TestCase/Service/BlogContentServiceTest.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\BlogContentService;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class BlogContentServiceTest extends TestCase
+{
+    public array $fixtures = ['app.Images'];
+
+    private BlogContentService $service;
+
+    /**
+     * Configure a credited fixture image for each test.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $imagesTable = TableRegistry::getTableLocator()->get('Images');
+        $image = $imagesTable->get(1);
+        $image->photo_credit = 'Murray State Athletics';
+        $imagesTable->saveOrFail($image);
+        $this->service = new BlogContentService($imagesTable);
+    }
+
+    /**
+     * Legacy inline image URLs should resolve their stored photo credit.
+     */
+    public function testRenderWithPhotoCreditsResolvesStoredImagePath(): void
+    {
+        $image = TableRegistry::getTableLocator()->get('Images')->get(1);
+        $body = '<p>Story text</p><picture><img src="/img/storage/' . $image->storage_path . '"></picture>';
+
+        $result = $this->service->renderWithPhotoCredits($body);
+
+        $this->assertStringContainsString('blog-image-credit', $result);
+        $this->assertStringContainsString('Photo: Murray State Athletics', $result);
+        $this->assertStringContainsString((string)$image->storage_path, $result);
+    }
+
+    /**
+     * New inline image markup should resolve credits using its image id.
+     */
+    public function testRenderWithPhotoCreditsResolvesImageId(): void
+    {
+        $body = '<p>Story text</p><img data-image-id="1" src="/img/storage/unknown.jpg">';
+
+        $result = $this->service->renderWithPhotoCredits($body);
+
+        $this->assertStringContainsString('data-image-id="1"', $result);
+        $this->assertStringContainsString('Photo: Murray State Athletics', $result);
+    }
+
+    /**
+     * Unknown images should remain unchanged rather than being rewritten.
+     */
+    public function testRenderWithPhotoCreditsLeavesUnknownImagesUnchanged(): void
+    {
+        $body = '<p>Story text</p><img src="https://example.com/photo.jpg">';
+
+        $this->assertSame($body, $this->service->renderWithPhotoCredits($body));
+    }
+
+    /**
+     * Rendering the same body twice should not duplicate its credit caption.
+     */
+    public function testRenderWithPhotoCreditsIsIdempotent(): void
+    {
+        $image = TableRegistry::getTableLocator()->get('Images')->get(1);
+        $body = '<picture><img src="/img/storage/' . $image->storage_path . '"></picture>';
+        $rendered = $this->service->renderWithPhotoCredits($body);
+
+        $this->assertSame($rendered, $this->service->renderWithPhotoCredits($rendered));
+        $this->assertSame(1, substr_count($rendered, 'blog-image-credit__label'));
+    }
+}

--- a/webroot/css/blog-content.css
+++ b/webroot/css/blog-content.css
@@ -181,6 +181,30 @@
     margin: 0;
 }
 
+.blog-image-credit {
+    display: inline-block;
+    max-width: 100%;
+    margin: 1rem 0;
+}
+
+.blog-image-credit > picture {
+    display: block;
+    margin: 0;
+}
+
+.blog-image-credit__label {
+    margin-top: 0.35rem;
+    color: var(--rh-muted);
+    font-size: 0.8rem;
+    line-height: 1.35;
+    text-align: left;
+}
+
+.blog-content .blog-image-credit.img-float-left,
+.blog-content .blog-image-credit.img-float-right {
+    margin-top: 0.5rem;
+}
+
 /* Float classes for images */
 .blog-content .img-float-left,
 .blog-content img[style*="float: left"],


### PR DESCRIPTION
Introduce a new BlogContentHelper and BlogContentService to render blog content with image credits. Update the blog post rendering to utilize the new service, ensuring images display with appropriate credits. Add tests to verify the functionality of the new service and its integration.

