### PR TITLE
fix: update PHP version requirement to 8.2 and remove TinyMCE check

### DIFF
--- a/src/Service/DeployAuditService.php
+++ b/src/Service/DeployAuditService.php
@@ -114,10 +114,10 @@ class DeployAuditService
         $ver = $major . '.' . $minor . '.' . PHP_RELEASE_VERSION;
 
         /** @phpstan-ignore-next-line */
-        if ($major >= 8 && $minor >= 1) {
+        if ($major >= 8 && $minor >= 2) {
             $this->ok($cat, "PHP {$ver}");
         } else {
-            $this->fail($cat, "PHP {$ver} — requires 8.1+");
+            $this->fail($cat, "PHP {$ver} — requires 8.2+");
         }
     }
 
@@ -235,7 +235,6 @@ class DeployAuditService
             'tmp', 'logs', 'tmp' . DS . 'cache',
             'tmp' . DS . 'cache' . DS . 'models',
             'tmp' . DS . 'cache' . DS . 'persistent',
-            'tmp' . DS . 'sessions',
             'webroot' . DS . 'img' . DS . 'storage',
         ];
         foreach ($dirs as $dir) {
@@ -389,13 +388,6 @@ class DeployAuditService
                     $this->fail($cat, 'Vite manifest missing js/main.js entry');
                 }
             }
-        }
-
-        // TinyMCE
-        if (is_dir(ROOT . DS . 'webroot' . DS . 'js' . DS . 'tinymce')) {
-            $this->ok($cat, 'TinyMCE library present');
-        } else {
-            $this->warn($cat, 'webroot/js/tinymce/ not found', 'Admin rich text editors will fail');
         }
     }
 }

--- a/tests/TestCase/Service/DeployAuditServiceTest.php
+++ b/tests/TestCase/Service/DeployAuditServiceTest.php
@@ -78,6 +78,25 @@ class DeployAuditServiceTest extends TestCase
     }
 
     /**
+     * Tests php version check fails below minimum supported version.
+     */
+    public function testPhpVersionCheckFailsBelowMinimum(): void
+    {
+        if (version_compare(PHP_VERSION, '8.2.0', '>=')) {
+            $this->markTestSkipped('This runtime is already PHP 8.2+; the negative-path is only valid on a lower version.');
+        }
+
+        $audit = $this->service->run();
+
+        $phpResults = array_filter($audit['results'], fn($r) => $r['category'] === 'PHP Version');
+        $this->assertNotEmpty($phpResults);
+
+        $first = array_values($phpResults)[0];
+        $this->assertSame('fail', $first['status']);
+        $this->assertStringContains('8.2+', $first['label']);
+    }
+
+    /**
      * Tests php extensions checked.
      */
     public function testPhpExtensionsChecked(): void


### PR DESCRIPTION
<!---

**PLEASE NOTE:**

This is only a issue tracker for issues related to the CakePHP Application Skeleton.
For CakePHP Framework issues please use this [issue tracker](https://github.com/cakephp/cakephp/issues).

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) guidelines when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
